### PR TITLE
Generalize for Basic Regex Searching

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,6 +7,14 @@
     files: ''
     stages: [commit, push, manual]
 
+-   id: regex
+    name: Search for disallowed text
+    description: Block commit when regex is found, like a TODO without a ticket number
+    entry: todo.py
+    language: script
+    files: ''
+    stages: [commit, push, manual]
+
 -   id: generated-sidecar
     name: Check for Generated Sidecars
     description: Block commit if sidecar files are not generated.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 This repository contains some pre-commit hooks for use with [pre-commit](https://pre-commit.com/).
 
-#### `todo`
+#### `todo` / 'regex'
 Ensures that TODO comments are removed, using the python re module to match lines.
   - `--search-pattern <pattern>` - Change the default grep pattern. The default looks for a
     ticket number directly after the TODO with: `^.*TODO:(?!\s*\[?[A-Z]{1,5}-\d+).*$`.
   - `--repo-skip-pattern <pattern>` - Skip the checks when the repo name matches the
     pattern, useful when allowing TODO comments in a `Template` repo.
     Default: `.*-template-.*`
+  - `--found-message` - Allow custom message when search-pattern is found (allows
+    generalization for basic regex).
 
 #### `sidecar`
 Ensures that sidecar file are up to date.

--- a/todo.py
+++ b/todo.py
@@ -23,6 +23,10 @@ def main():
         default=r"^.*TODO:(?!\s*\[?[A-Z]{1,5}-\d+).*$",
     )
     parser.add_argument("--repo-skip-pattern", default=".*-template-.*")
+    parser.add_argument(
+        "--found-message",
+        default="Search pattern found. Please remove or add tracking ticket.",
+    )
     parser.add_argument("filenames", nargs="*")
     args = parser.parse_args()
 
@@ -42,7 +46,7 @@ def main():
                     continue
 
         if matches:
-            err("Error: Search pattern found. Please remove or add tracking ticket.")
+            err(f"Error: {args.found_message}")
             for match in matches:
                 err(f"  {match[0]}:{match[1]} - {match[2]}")
             err("")


### PR DESCRIPTION
The todo check was also perfect for searching for FQDNs in some k8s deployments, so you can use something like:
```
- repo: https://github.com/KyleJamesWalker/pre-commit-hooks
  rev: "0705410"
  hooks:
    - id: regex
      args:
        - --search-pattern
        - ^.*\.svc\.cluster\.local
        - --found-message
        - "Found a .svc.cluster.local in the file. Please maintain namespace isolation."
```