### PR TITLE
Update Stage Names

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,7 +5,7 @@
     entry: todo.py
     language: script
     files: ''
-    stages: [commit, push, manual]
+    stages: [pre-commit, pre-push, manual]
 
 -   id: regex
     name: Search for disallowed text
@@ -13,7 +13,7 @@
     entry: todo.py
     language: script
     files: ''
-    stages: [commit, push, manual]
+    stages: [pre-commit, pre-push, manual]
 
 -   id: generated-sidecar
     name: Check for Generated Sidecars
@@ -23,4 +23,4 @@
     always_run: true
     pass_filenames: false
     files: ''
-    stages: [commit, push]
+    stages: [pre-commit, pre-push]


### PR DESCRIPTION
Fix the following warning:
```
[WARNING] repo `https://github.com/KyleJamesWalker/pre-commit-hooks` uses deprecated stage names (commit, push) which will be removed in a future version.  Hint: often `pre-commit autoupdate --repo https://github.com/KyleJamesWalker/pre-commit-hooks` will fix this.  if it does not -- consider reporting an issue to that repo.
```

# Details

> New in 3.2.0: The values of stages match the hook names. Previously, commit, push, and merge-commit matched pre-commit, pre-push, and pre-merge-commit respectively.

Source: [Confining hooks to run at certain stages](https://pre-commit.com/#confining-hooks-to-run-at-certain-stages)