### PR TITLE
Support git commit time as age source in sidecar checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ensures that TODO comments are removed, using the python re module to match line
 Ensures that sidecar file are up to date.
   - `--sidecar=<primary>:<sidecar>` - Fail if the commit for the `primary` file does not
     include the `sidecar` file.
-  - `--age=<sidecar>:<age>` - Fail if the `sidecar` file is older than the specified age.
+  - `--age=<file>:<age>[:<source>]` - Fail if the `file` is older than the specified age.
     The age is a string formatted with: `30d5h`.
     Note the following units are supported:
     - `s` (seconds)
@@ -26,6 +26,16 @@ Ensures that sidecar file are up to date.
     - `w` (weeks)
     - `M` (months)
     - `y` (years)
+
+    The optional `source` controls how file age is determined:
+    - `commit` (default) — uses `git log` to find the last commit time. This works
+      correctly on freshly cloned repos where filesystem timestamps are all recent.
+    - `mtime` — uses the filesystem modification time.
+
+    Examples:
+    - `--age=poetry.lock:30d` — fails if poetry.lock was last committed over 30 days ago
+    - `--age=poetry.lock:30d:commit` — same as above (explicit)
+    - `--age=poetry.lock:30d:mtime` — uses filesystem modification time instead
 
 #### `decorator-kwargs`
 Ensures that Python decorators include required keyword arguments. This hook checks

--- a/sidecar.py
+++ b/sidecar.py
@@ -99,17 +99,70 @@ def parse_time_string(time_string):
         raise ValueError(f"Invalid time string: {time_string}")
 
 
+def get_commit_time(filename: str) -> datetime.datetime | None:
+    """Get the last commit time for a file from git history."""
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%ct", "--", filename],
+        stdout=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode == 0:
+        timestamp = result.stdout.decode("utf-8").strip()
+        if timestamp:
+            return datetime.datetime.fromtimestamp(int(timestamp))
+    return None
+
+
+def get_file_age(filename: str, source: str) -> datetime.timedelta | None:
+    """Get the age of a file based on the source type.
+
+    Args:
+        filename: Path to the file.
+        source: One of "commit" (git log) or "mtime" (filesystem modification time).
+
+    Returns:
+        A timedelta representing the file's age, or None if the age
+        could not be determined.
+    """
+    now = datetime.datetime.now()
+    if source == "commit":
+        commit_time = get_commit_time(filename)
+        if commit_time is None:
+            err(f"Warning: No git history for {filename}, falling back to mtime.")
+            return now - datetime.datetime.fromtimestamp(os.path.getmtime(filename))
+        return now - commit_time
+    else:
+        return now - datetime.datetime.fromtimestamp(os.path.getmtime(filename))
+
+
 def age_checks(age_rules: list) -> int:
-    """Check if the sidecar files are updated based on the rules provided."""
+    """Check if the sidecar files are updated based on the rules provided.
+
+    Rule format: filename:age[:source]
+        source is "commit" (default) or "mtime".
+    """
     result = 0
     for rule in age_rules:
-        filename, age = rule.split(":")
-        age = parse_time_string(age)
-        file_age = datetime.datetime.now() - datetime.datetime.fromtimestamp(
-            os.path.getmtime(filename)
-        )
-        if file_age > age:
-            err(f"Error: {filename} is older than {age}.")
+        parts = rule.split(":")
+        if len(parts) == 3:
+            filename, age, source = parts
+        elif len(parts) == 2:
+            filename, age = parts
+            source = "commit"
+        else:
+            err(f"Error: Invalid age rule: {rule}")
+            result += 1
+            continue
+
+        if source not in ("commit", "mtime"):
+            err(f"Error: Invalid age source '{source}', expected 'commit' or 'mtime'.")
+            result += 1
+            continue
+
+        max_age = parse_time_string(age)
+        file_age = get_file_age(filename, source)
+        if file_age is not None and file_age > max_age:
+            err(f"Error: {filename} is older than {max_age} (source: {source}).")
             result += 1
     return result
 


### PR DESCRIPTION
## Purpose
Support git commit time as age source in sidecar checks

## Changes
The `--age` rule previously relied on filesystem modification time (`mtime`), which resets to the current time on a fresh `git clone`. This meant files untouched for years would never trigger the age check on freshly checked-out repos.

This adds `git log`-based commit time discovery as the default age source. The rule format is extended to `filename:age[:source]` where `source` is `commit` (default) or `mtime`, preserving backward compatibility for users who want filesystem timestamps.

## Testing
- [ ] Verify `commit` source correctly reads last commit timestamp
- [ ] Verify `mtime` source preserves existing behavior
- [ ] Verify graceful fallback to `mtime` when git history is unavailable
- [ ] Verify backward compatibility with existing `filename:age` rules (no source specified)

## Impact
- Default age source changes from `mtime` to `commit` — existing users on fresh clones will now correctly detect stale files
- Backward compatible: existing rule format `filename:age` continues to work (defaults to `commit`)
- Explicit `mtime` source available for users who prefer filesystem timestamps

## Checklist
- [x] Conventional commit messages used
- [x] No breaking changes to existing API
- [x] Backward compatible rule format

---
```
(\__/)
(+'.'+)
(")_(")
```
Bunny helped with this PR and is one step closer to world domination...
