### PR TITLE
fix(sidecar): correctly parse git status -s XY filename format

### DIFF
--- a/sidecar.py
+++ b/sidecar.py
@@ -40,9 +40,9 @@ def get_commit_files() -> list:
     )
 
     if result.returncode == 0:
-        # Convert `M file-name.example\n...` to a list of file names with commit type
+        # git status -s format is XY<space>filename; strip both parts cleanly
         files = [
-            FileStatus(*x.strip().split(" ", 1))
+            FileStatus(x[:2].strip(), x[3:])
             for x in result.stdout.decode("utf-8").split("\n")
             if x.strip()
         ]


### PR DESCRIPTION
## Summary

- Fixes `get_commit_files()` to correctly parse the two-char `XY` status prefix from `git status -s`
- The previous `split(" ", 1)` left a leading space on the filename (e.g. `" poetry.lock"` instead of `"poetry.lock"`), causing staged-file lookups to never match
- This broke the age-check bypass from v1.0.1 — staged files were never recognized, so the stale age error still fired

## Test plan

- [ ] Stage a file covered by an `--age` rule that would otherwise be stale, verify the hook passes
- [ ] Leave the same file unstaged and stale, verify the hook still fails as expected

---
```
(\__/)
(+'.'+)
(")_(")
```
Bunny helped with this PR and is one step closer to world domination...
