### PR TITLE
feat(todo): add --warn-only flag for non-blocking TODO warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Ensures that TODO comments are removed, using the python re module to match line
     Default: `.*-template-.*`
   - `--found-message` - Allow custom message when search-pattern is found (allows
     generalization for basic regex).
+  - `--warn-only` - Report matches as warnings and exit 0 instead of failing. Also
+    scans repos matching `--repo-skip-pattern`, so a `Template` repo can surface the
+    TODOs that will start blocking once the hook enforces normally (pair with
+    pre-commit's `verbose: true` so the warnings show on a passing run).
 
 #### `generated-sidecar`
 Ensures that sidecar file are up to date.

--- a/todo.py
+++ b/todo.py
@@ -27,10 +27,22 @@ def main():
         "--found-message",
         default="Search pattern found. Please remove or add tracking ticket.",
     )
+    parser.add_argument(
+        "--warn-only",
+        action="store_true",
+        help=(
+            "Report matches as warnings and exit 0 instead of failing. Also scans "
+            "repos that match --repo-skip-pattern, so template repos can surface the "
+            "TODOs that will start blocking once the hook enforces normally."
+        ),
+    )
     parser.add_argument("filenames", nargs="*")
     args = parser.parse_args()
 
-    if re.search(args.repo_skip_pattern, os.getcwd().split(os.sep)[-1]):
+    skip_repo = re.search(args.repo_skip_pattern, os.getcwd().split(os.sep)[-1])
+    # Normally a skip-pattern (template) repo does nothing. --warn-only overrides
+    # that so matches are still surfaced for visibility, just never block.
+    if skip_repo and not args.warn_only:
         # Skip the hook when requested for template repos.
         pass
     else:
@@ -46,11 +58,11 @@ def main():
                     continue
 
         if matches:
-            err(f"Error: {args.found_message}")
+            err(f"{'Warning' if args.warn_only else 'Error'}: {args.found_message}")
             for match in matches:
                 err(f"  {match[0]}:{match[1]} - {match[2]}")
             err("")
-            return_val = 1
+            return_val = 0 if args.warn_only else 1
 
     return return_val
 


### PR DESCRIPTION
## Summary

Adds a `--warn-only` flag to the `todo` hook so a TODO check can be **non-blocking and visible** instead of either failing the commit or being silently skipped.

Two behavior changes when `--warn-only` is set:
- Matches are reported as `Warning:` and the hook **exits 0** (never blocks).
- The hook **scans even when `--repo-skip-pattern` matches** (e.g. a `*-template-*` repo), so a template repo can surface the TODOs that will start blocking once it's renamed/instantiated.

Default behavior is unchanged when the flag is absent: skip-pattern repos still skip silently, everything else still blocks on an untracked TODO.

## Motivation

Template repos (e.g. `zefr-airflow-dag-template-py`) ship intentional `TODO:` placeholders. Today the hook skips them silently via `--repo-skip-pattern`, so devs can't see which TODOs become blocking after rename. Pairing `--warn-only` with pre-commit's `verbose: true` lists that pending TODO debt on every passing run.

## Behavior matrix

| Context | Flag | Result |
|---|---|---|
| skip-pattern repo (template) | none | silent skip, exit 0 (unchanged) |
| skip-pattern repo (template) | `--warn-only` | prints `Warning:` + matches, exit 0 |
| normal repo | none | prints `Error:` + matches, exit 1 (unchanged) |
| normal repo | `--warn-only` | prints `Warning:` + matches, exit 0 |

## Notes

- No release/tag cut here — a maintainer will tag the release (consumer pins `v1.1.0`).

---
```
(\__/)
(+'.'+)
(")_(")
```
Bunny helped with this PR and is one step closer to world domination...
