### PR TITLE
Add prose-lint hooks for documentation and code comments

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -62,3 +62,27 @@
     types: [text]
     files: '\.(py|pyi|js|jsx|mjs|cjs|ts|tsx|go|rs|java|kt|kts|scala|c|h|cpp|cc|hpp|cs|rb|sh|bash|zsh|php|swift|dart|lua|sql|tf|tfvars|proto|groovy|gradle|css|scss|less|erl|ex|exs|ps1|vue|html|xml)$'
     stages: [pre-commit, pre-push, manual]
+
+# Warn-only variants. Same checks, reported without blocking the commit, for a
+# repository adopting the hook on documentation it did not write. `verbose: true`
+# is required: pre-commit hides the output of a passing hook, and these always
+# pass, so without it the warnings are never shown.
+-   id: prose-lint-warn
+    name: Lint prose in documentation (warn only)
+    description: Report documentation prose over the style budget without failing.
+    entry: prose_lint.py --profile docs --warn-only
+    language: script
+    types: [text]
+    files: '\.(md|markdown|mdx|rst|txt|adoc|org)$'
+    stages: [pre-commit, pre-push, manual]
+    verbose: true
+
+-   id: prose-lint-comments-warn
+    name: Lint prose in code comments (warn only)
+    description: Report slop in comments or docstrings without failing.
+    entry: prose_lint.py --profile comments --warn-only
+    language: script
+    types: [text]
+    files: '\.(py|pyi|js|jsx|mjs|cjs|ts|tsx|go|rs|java|kt|kts|scala|c|h|cpp|cc|hpp|cs|rb|sh|bash|zsh|php|swift|dart|lua|sql|tf|tfvars|proto|groovy|gradle|css|scss|less|erl|ex|exs|ps1|vue|html|xml)$'
+    stages: [pre-commit, pre-push, manual]
+    verbose: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -44,3 +44,21 @@
     pass_filenames: false
     files: ''
     stages: [pre-commit, pre-push]
+
+-   id: prose-lint
+    name: Lint prose in documentation
+    description: Block commit when documentation prose is over the style budget.
+    entry: prose_lint.py --profile docs
+    language: script
+    types: [text]
+    files: '\.(md|markdown|mdx|rst|txt|adoc|org)$'
+    stages: [pre-commit, pre-push, manual]
+
+-   id: prose-lint-comments
+    name: Lint prose in code comments
+    description: Block commit when comments or docstrings contain slop.
+    entry: prose_lint.py --profile comments
+    language: script
+    types: [text]
+    files: '\.(py|pyi|js|jsx|mjs|cjs|ts|tsx|go|rs|java|kt|kts|scala|c|h|cpp|cc|hpp|cs|rb|sh|bash|zsh|php|swift|dart|lua|sql|tf|tfvars|proto|groovy|gradle|css|scss|less|erl|ex|exs|ps1|vue|html|xml)$'
+    stages: [pre-commit, pre-push, manual]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,42 @@
 
 This repository contains some pre-commit hooks for use with [pre-commit](https://pre-commit.com/).
 
+## Warn-only mode
+
+Hooks block by default. A hook that also supports `--warn-only` reports its
+findings and exits 0, so a repository can adopt a check on content it did not
+write before the backlog is clean.
+
+The convention for every hook here:
+
+- `--warn-only` downgrades **findings** to warnings and exits 0. A configuration
+  or usage error still fails, because a misconfigured hook is not a warning.
+- Warning output says `WARN`, never `FAIL`. A report that says both on one screen
+  leaves the reader guessing which half to believe.
+- Pair it with pre-commit's `verbose: true`. Pre-commit hides the output of a
+  passing hook, and a warn-only hook always passes, so without `verbose` the
+  warnings are never shown.
+
+Supported by `todo` / `regex` and by both `prose-lint` hooks. Pass the flag
+yourself:
+
+```yaml
+-   id: prose-lint
+    args: [--warn-only]
+    verbose: true
+```
+
+`prose-lint` also ships ready-made warn ids, `prose-lint-warn` and
+`prose-lint-comments-warn`, which set the flag and `verbose` for you.
+
+A useful pairing is to block on what a team controls and warn on the rest:
+
+```yaml
+-   id: prose-lint-comments        # blocks: comments are written here
+-   id: prose-lint-warn           # warns: inherited documentation
+    files: ^docs/
+```
+
 #### `todo` / 'regex'
 Ensures that TODO comments are removed, using the python re module to match lines.
   - `--search-pattern <pattern>` - Change the default grep pattern. The default looks for a
@@ -154,12 +190,19 @@ Lints prose against the machine-checkable subset of
 [ASD-STE100](https://asd-ste100.org) Simplified Technical English: word choice,
 sentence length, voice, hedging, marketing language and paragraph size.
 
-Language agnostic. Two hook ids share one script:
+Language agnostic. Four hook ids share one script:
 
 - `prose-lint` lints documentation files whole (`.md`, `.rst`, `.txt`, and more).
 - `prose-lint-comments` lints only the comments and docstrings in source files,
   across roughly 60 extensions. It never scores code, identifiers or string
   literals, so it skips a quoted `"// not a comment"` and a URL containing `#`.
+- `prose-lint-warn` and `prose-lint-comments-warn` run the same checks and report
+  without blocking. See [Warn-only mode](#warn-only-mode).
+
+Which to pick depends on how much prose the repository already carries. Measured
+across 17 repositories, a service or template repo has almost no documentation in
+a typical commit, so the blocking ids cost nothing. A documentation-heavy repo is
+the opposite case: start on the warn ids, clear the backlog, then switch.
 
 The hook picks comment syntax from the file extension: `#`, `//`, `/* */`, `--`,
 `;`, `%`, `<!-- -->`, `<# #>`, plus Python docstrings and Ruby `=begin` blocks.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,18 @@ Examples:
     ```
 
 # Development
+
+`prose_lint.py` has a test suite. Run it from the repository root with the
+standard library alone:
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+`tests/test_prose_lint.py` pins current behaviour, including a golden document
+checked check by check. A rule change is expected to move those numbers: update
+them in the same commit, so the diff shows what the change did to the score.
+
 To develop and test the hooks, you can use the `pre-commit try-repo` command, from
 another repo using these hooks. For example:
 

--- a/README.md
+++ b/README.md
@@ -171,12 +171,42 @@ Detection is heuristic, not a parser. It handles line and block comments, string
 literals with backslash escapes, and triple-quoted strings. It does not attempt
 nested block comments or interpolated expressions inside template strings.
 
-**Enforcement.** Every finding carries a weight. A file fails when either
-mechanism trips:
+The document profiles mirror the `technical-writing` skill's linter, which is the
+source of truth for the rule lists, the thresholds, the 100-word floor and the
+short-doc allowance. Two tools disagreeing about one document is its own problem,
+so every default here matches it. The `comments` profile has no counterpart in the
+skill and is documented on its own terms below.
 
-- **threshold** — weighted violations per 100 words. This puts long and short
-  prose on the same scale.
+**Enforcement.** Every finding carries a weight, and every check defaults to 1.0,
+so the score is a plain violation count per 100 words. Re-weight a check to make
+it advisory or to make it count double. A file fails when any mechanism trips:
+
+- **threshold** — weighted violations per 100 words, for prose at or above
+  `min_words`. This puts long and short prose on the same scale.
+- **short-doc rule** — below `min_words` a rate is meaningless, so the absolute
+  violation count applies instead. See below.
 - **max** — an absolute count for a check, for zero tolerance regardless of length.
+
+Below `min_words` a rate says more about length than about quality. At the default
+threshold of 2.0, prose gets 50 words of runway per allowed violation. One defect
+then passes at 52 words and fails at 45. A 50-word index page with two defects
+scores 4.00, which ranks it below a 2000-word document at 3.56.
+
+The short-doc rule counts violations against `short_allowance` instead, and
+reports no rate. The two mechanisms agree at the handover. Under `docs` defaults
+one violation passes at every length, and two violations fail below 100 words,
+where the rate itself starts to allow them.
+
+An allowance of 1 was chosen over the alternatives. Zero lets a single `don't`
+gate a commit. Two means nothing short can realistically fail, so the check stops
+catching anything. A denominator floor was rejected on purpose: it reports a rate
+that was never measured, and a reader seeing 1.0 on a 23-word file would infer
+0.23 violations.
+
+The `comments` profile sets `short_allowance` to `null`, which disables the rule
+and leaves only the per-check caps. A count rule on a terse comment would cap the
+banned-word list by the back door. The rate-based split below exists to prevent
+exactly that.
 
 The `comments` profile caps marketing words, hedges and empty closers at zero.
 One of those in a comment is worth flagging however short the comment is. The
@@ -187,19 +217,26 @@ absolute cap would fail normal code on its first commit.
 **Profiles** set the starting point. Configuration resolves in three layers:
 profile, then `--config`, then command-line flags.
 
-  | Profile | For | Checks | Threshold | Sentence cap |
-  |---|---|---|---|---|
-  | `docs` (default) | READMEs, design docs, guides | all 13 | 2.0 | 25 words |
-  | `strict` | runbooks, procedures, error text | all 13 | 0.5 | 20 words |
-  | `comments` | source-code comments | 4 high-signal | 2.0 | 30 words |
+  | Profile | For | Checks | Threshold | Sentence cap | Short doc |
+  |---|---|---|---|---|---|
+  | `docs` (default) | READMEs, design docs, guides | 12, no intensifier | 2.0 | 25 words | under 100 words, max 1 |
+  | `strict` | runbooks, procedures, error text | all 13 | 0.5 | 20 words | under 100 words, max 0 |
+  | `comments` | source-code comments | 4 high-signal | 2.0 | 30 words | rule disabled |
+
+`docs` leaves `intensifier` off, matching the skill: `significantly` and `highly`
+carry real meaning in a design doc, and the relaxed word list is what lets standard
+prose keep its range. `strict` turns it on.
 
 **Options**
   - `--profile <docs|strict|comments>` - rule preset. Default: `docs`.
   - `--config <config>` - JSON configuration, as a file path or an inline string.
   - `--threshold <number>` - maximum weighted violations per 100 words.
-  - `--min-words <n>` - below this word count only absolute caps apply, because a
-    rate is noise on very short prose. Defaults: 50 (`docs`), 30 (`strict`),
-    40 (`comments`).
+  - `--min-words <n>` - below this word count the short-doc rule applies instead
+    of the rate, because a rate is noise on very short prose. Defaults: 100
+    (`docs`), 100 (`strict`), 40 (`comments`).
+  - `--short-allowance <n>` - violations tolerated below `--min-words`. Defaults:
+    1 (`docs`), 0 (`strict`), disabled for `comments`. Set it to `null` in a JSON
+    config to disable the rule and leave only the per-check caps.
   - `--max-sentence-words <n>` / `--max-paragraph-sentences <n>` - length caps.
     Set the paragraph cap to `0` to disable it.
   - `--enable <check>` / `--disable <check>` - toggle one check. Repeatable.
@@ -213,6 +250,13 @@ profile, then `--config`, then command-line flags.
     with pre-commit's `verbose: true` so warnings show on a passing run.
   - `--quiet` - omit the quoted excerpt under each finding.
   - `--json` - machine-readable results, for reporting or a CI budget check.
+    Emits a list of one object per file.
+  - `--total` - add a corpus rollup across every file in the run: word count,
+    failing count, short-document count, pooled score, longest sentence and the
+    share each check contributes. The pooled score comes from the total weight over the total word
+    count, so a long file counts for more than a three-line one. Use it to tell
+    whether a corpus has a padding problem or a sentence-length problem. With
+    `--json` the top level becomes `{"files": [...], "total": {...}}`.
   - `--list-checks` - print every check with its default weight and profiles.
 
 **Checks**: `long_sentence`, `long_paragraph`, `semicolon`, `contraction`,
@@ -225,7 +269,8 @@ Run `--list-checks` for default weights.
 {
   "profile": "docs",
   "threshold": 2.0,
-  "min_words": 50,
+  "min_words": 100,
+  "short_allowance": 1,
   "max_sentence_words": 25,
   "max_paragraph_sentences": 6,
   "checks": {
@@ -242,9 +287,14 @@ Keys are optional. `checks` accepts `enabled`, `weight` and `max` per check.
 `allow` removes words from the defaults, `extra_banned` and `extra_marketing`
 add project-specific ones.
 
-**Suppression**. To exempt prose that must quote bad writing, use a marker in a
-comment. The single-line form covers the whole paragraph it appears in, because a
-sentence can wrap across several lines.
+**Suppression**. The linter skips inline code, so put a literal value copied from
+another system in backticks: `` `Won't Do` ``, `` `PENDING_REVIEW` ``. That is
+data, not your prose, and fencing it exempts it from every check while also being
+more accurate. Reach for a marker only when the prose itself has to break a rule.
+
+To exempt prose that must quote bad writing, use a marker in a comment. The
+single-line form covers the whole paragraph it appears in, because a sentence can
+wrap across several lines.
 
 ```markdown
 This paragraph quotes a bad example. <!-- prose-lint: ignore -->

--- a/README.md
+++ b/README.md
@@ -149,6 +149,142 @@ and the script validates all pairs of files to ensure they are synchronized.
       file1.yaml "" file2.yaml "" --config '{"rules": [{"keys": ["*"], "type": "exact_match"}]}'
       ```
 
+#### `prose-lint` / `prose-lint-comments`
+Lints prose against the machine-checkable subset of
+[ASD-STE100](https://asd-ste100.org) Simplified Technical English: word choice,
+sentence length, voice, hedging, marketing language and paragraph size.
+
+Language agnostic. Two hook ids share one script:
+
+- `prose-lint` lints documentation files whole (`.md`, `.rst`, `.txt`, and more).
+- `prose-lint-comments` lints only the comments and docstrings in source files,
+  across roughly 60 extensions. It never scores code, identifiers or string
+  literals, so it skips a quoted `"// not a comment"` and a URL containing `#`.
+
+The hook picks comment syntax from the file extension: `#`, `//`, `/* */`, `--`,
+`;`, `%`, `<!-- -->`, `<# #>`, plus Python docstrings and Ruby `=begin` blocks.
+It drops javadoc ornament (`*`) and machine-readable directives (`@param`,
+`# noqa`, `Args:`) before linting. It also rejoins consecutive comment lines, so
+it measures a sentence wrapped across several of them as one sentence.
+
+Detection is heuristic, not a parser. It handles line and block comments, string
+literals with backslash escapes, and triple-quoted strings. It does not attempt
+nested block comments or interpolated expressions inside template strings.
+
+**Enforcement.** Every finding carries a weight. A file fails when either
+mechanism trips:
+
+- **threshold** — weighted violations per 100 words. This puts long and short
+  prose on the same scale.
+- **max** — an absolute count for a check, for zero tolerance regardless of length.
+
+The `comments` profile caps marketing words, hedges and empty closers at zero.
+One of those in a comment is worth flagging however short the comment is. The
+banned-word list stays rate-based there, because it spans two different things.
+`utilize` is clear slop. `ensure` reads as ordinary English in a docstring. An
+absolute cap would fail normal code on its first commit.
+
+**Profiles** set the starting point. Configuration resolves in three layers:
+profile, then `--config`, then command-line flags.
+
+  | Profile | For | Checks | Threshold | Sentence cap |
+  |---|---|---|---|---|
+  | `docs` (default) | READMEs, design docs, guides | all 13 | 2.0 | 25 words |
+  | `strict` | runbooks, procedures, error text | all 13 | 0.5 | 20 words |
+  | `comments` | source-code comments | 4 high-signal | 2.0 | 30 words |
+
+**Options**
+  - `--profile <docs|strict|comments>` - rule preset. Default: `docs`.
+  - `--config <config>` - JSON configuration, as a file path or an inline string.
+  - `--threshold <number>` - maximum weighted violations per 100 words.
+  - `--min-words <n>` - below this word count only absolute caps apply, because a
+    rate is noise on very short prose. Defaults: 50 (`docs`), 30 (`strict`),
+    40 (`comments`).
+  - `--max-sentence-words <n>` / `--max-paragraph-sentences <n>` - length caps.
+    Set the paragraph cap to `0` to disable it.
+  - `--enable <check>` / `--disable <check>` - toggle one check. Repeatable.
+  - `--weight <check>=<number>` - re-weight one check. Repeatable.
+  - `--max <check>=<integer>` - absolute cap for one check. Repeatable.
+  - `--allow <word>` - drop a word from the banned and marketing lists, for a
+    project where it is a domain term. Repeatable.
+  - `--exclude <glob>` - skip matching paths. Repeatable.
+  - `--include-unknown` - treat extensionless files as documentation.
+  - `--warn-only` - report findings and exit 0, matching the `todo` hook. Pair
+    with pre-commit's `verbose: true` so warnings show on a passing run.
+  - `--quiet` - omit the quoted excerpt under each finding.
+  - `--json` - machine-readable results, for reporting or a CI budget check.
+  - `--list-checks` - print every check with its default weight and profiles.
+
+**Checks**: `long_sentence`, `long_paragraph`, `semicolon`, `contraction`,
+`passive_voice`, `ing_main_verb`, `nominalization`, `phrasal_verb`,
+`banned_word`, `marketing_adjective`, `hedge`, `intensifier`, `empty_closer`.
+Run `--list-checks` for default weights.
+
+**JSON config format**
+```json
+{
+  "profile": "docs",
+  "threshold": 2.0,
+  "min_words": 50,
+  "max_sentence_words": 25,
+  "max_paragraph_sentences": 6,
+  "checks": {
+    "marketing_adjective": {"weight": 3.0, "max": 0},
+    "passive_voice": {"enabled": false}
+  },
+  "allow": ["ensure"],
+  "extra_banned": {"k8s": "Kubernetes"},
+  "extra_marketing": ["synergy"]
+}
+```
+
+Keys are optional. `checks` accepts `enabled`, `weight` and `max` per check.
+`allow` removes words from the defaults, `extra_banned` and `extra_marketing`
+add project-specific ones.
+
+**Suppression**. To exempt prose that must quote bad writing, use a marker in a
+comment. The single-line form covers the whole paragraph it appears in, because a
+sentence can wrap across several lines.
+
+```markdown
+This paragraph quotes a bad example. <!-- prose-lint: ignore -->
+
+<!-- prose-lint: ignore-start -->
+Everything here is skipped.
+<!-- prose-lint: ignore-end -->
+```
+
+In source files use the language's comment syntax, for example
+`# prose-lint: ignore` or `// prose-lint: ignore-start`.
+
+**Exit codes**: `0` pass, `1` prose over budget, `2` bad configuration or an
+unreadable file.
+
+Examples:
+  - Documentation, default budget:
+    ```yaml
+    -   id: prose-lint
+    ```
+  - Runbooks under a stricter budget, docs under the normal one:
+    ```yaml
+    -   id: prose-lint
+        args: [--profile, strict]
+        files: ^runbooks/
+    -   id: prose-lint
+        files: ^docs/
+    ```
+  - Comments, warning only at first, with a project term allowed:
+    ```yaml
+    -   id: prose-lint-comments
+        args: [--warn-only, --allow, leverage]
+        verbose: true
+    ```
+  - Shared config file, checked into the repo:
+    ```yaml
+    -   id: prose-lint
+        args: [--config, .prose-lint.json]
+    ```
+
 # Development
 To develop and test the hooks, you can use the `pre-commit try-repo` command, from
 another repo using these hooks. For example:

--- a/README.md
+++ b/README.md
@@ -264,6 +264,23 @@ prose keep its range. `strict` turns it on.
 `banned_word`, `marketing_adjective`, `hedge`, `intensifier`, `empty_closer`.
 Run `--list-checks` for default weights.
 
+Four checks carry exemptions, because the rule they state is not the rule a
+reader wants applied everywhere:
+
+  - `semicolon` skips headings, table cells and list items without terminal
+    punctuation. Its fix is "write two sentences", and none of those three has
+    room for two. `TL;DR` is one token.
+  - `passive_voice` skips predicate adjectives such as `is needed` and
+    `is unchanged`, where naming an actor produces a worse sentence.
+  - `ing_main_verb` skips participles that report a state, such as
+    `is running` and `is missing`.
+  - `nominalization` skips concrete nouns that merely end in a nominalising
+    suffix, such as `the location of`, and requires `perform` and `conduct` to
+    carry a nominalised object.
+
+Use `--allow WORD` to drop a single word from the banned and marketing lists,
+and the JSON config to re-weight or disable a whole check.
+
 **JSON config format**
 ```json
 {

--- a/prose_lint.py
+++ b/prose_lint.py
@@ -700,7 +700,12 @@ def word_count(text):
 
 
 def excerpt(text, width=68):
-    text = " ".join(text.split())
+    # Slice before normalising. Only the first `width` characters can survive the
+    # truncation below, so collapsing whitespace across the whole text is wasted
+    # work -- and it is charged once per finding, which makes a paragraph that
+    # yields a finding every few words cost O(n^2). A 137KB single paragraph took
+    # 3.4s before this slice and 0.02s after.
+    text = " ".join(text[:width * 8].split())
     return text if len(text) <= width else text[:width - 1] + "..."
 
 

--- a/prose_lint.py
+++ b/prose_lint.py
@@ -1,0 +1,990 @@
+#!/usr/bin/env python3
+r"""Pre-commit hook to lint prose in documentation and in source-code comments.
+
+Language agnostic. Documentation files are linted whole. Source files are
+scanned for comments and docstrings, and only that prose is linted, so code,
+identifiers and string literals are never scored.
+
+The rules are the machine-checkable subset of ASD-STE100 Simplified Technical
+English: word choice, sentence length, voice, hedging, marketing language and
+paragraph size. Judgment rules (is the noun the right noun, is the claim true)
+need a human and are not checked here.
+
+Two independent enforcement mechanisms, both configurable per check:
+  threshold - weighted violations per 100 words, for prose of any length
+  max       - absolute count cap, for zero-tolerance checks
+
+Every check can be enabled, disabled or re-weighted, so a project can tune the
+rule set without editing this file. Configuration comes from a profile, then a
+JSON config, then command-line flags, each overriding the last.
+
+Run --list-checks for the check names and their default weights. The README
+documents the JSON schema and every flag, with examples.
+"""
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import shlex
+import sys
+
+# --------------------------------------------------------------------------- #
+# Rule data
+# --------------------------------------------------------------------------- #
+
+# phrase -> plain replacement ("" means delete the phrase)
+BANNED = {
+    "utilize": "use", "utilizes": "use", "utilized": "used", "utilizing": "using",
+    "utilization": "use",
+    "leverage": "use", "leverages": "uses", "leveraged": "used", "leveraging": "using",
+    "facilitate": "help", "facilitates": "helps", "facilitated": "helped",
+    "ensure": "make sure", "ensures": "makes sure", "ensuring": "making sure",
+    "commence": "start", "commences": "starts", "commenced": "started",
+    "initiate": "start", "initiates": "starts", "initiated": "started",
+    "terminate": "stop", "terminates": "stops", "terminated": "stopped",
+    "obtain": "get", "obtains": "gets", "obtained": "got",
+    "acquire": "get", "acquires": "gets", "acquired": "got",
+    "demonstrate": "show", "demonstrates": "shows", "demonstrated": "showed",
+    "endeavor": "try", "endeavour": "try",
+    "methodology": "method", "aforementioned": "this",
+    "approximately": "about", "regarding": "about", "concerning": "about",
+    "whilst": "while", "amongst": "among",
+    "numerous": "many", "myriad": "many", "plethora": "many",
+    "additionally": "also", "furthermore": "also", "moreover": "also",
+    "henceforth": "", "therein": "", "thereof": "", "herein": "",
+    "in order to": "to",
+    "in the event that": "if",
+    "due to the fact that": "because",
+    "for the purpose of": "to",
+    "at this point in time": "now",
+    "at the present time": "now",
+    "a variety of": "several",
+    "a number of": "several",
+    "the fact that": "that",
+    "is able to": "can", "are able to": "can",
+    "has the ability to": "can", "have the ability to": "can",
+    "in terms of": "for",
+    "with respect to": "about",
+    "with regard to": "about",
+    "on a regular basis": "regularly",
+    "prior to": "before",
+    "subsequent to": "after",
+    "serves as": "is", "acts as": "is",
+}
+
+MARKETING = [
+    "seamless", "seamlessly", "robust", "powerful", "cutting-edge", "effortless",
+    "effortlessly", "world-class", "next-generation", "revolutionary", "blazing",
+    "lightning-fast", "elegant", "delightful", "turnkey", "best-in-class",
+    "state-of-the-art", "game-changing", "first-class", "battle-tested",
+    "enterprise-grade", "supercharge", "unleash", "empower", "empowers",
+    "rich set of", "sensible defaults", "minimal friction", "out of the box",
+]
+
+PHRASAL = {
+    "spin up": "start", "spin down": "stop", "spun up": "started",
+    "reach out": "ask", "reaching out": "asking",
+    "dive into": "examine", "dives into": "examines", "diving into": "examining",
+    "delve into": "examine", "deep dive": "review",
+    "kick off": "start", "kicks off": "starts", "kicked off": "started",
+    "roll out": "deploy", "rolls out": "deploys", "rolled out": "deployed",
+    "tear down": "remove", "ramp up": "increase",
+    "circle back": "revisit", "drill down": "examine",
+}
+
+HEDGE = [
+    "it is important to note", "it should be noted", "it is worth noting",
+    "please note that", "as mentioned above", "as noted above", "as we all know",
+    "needless to say", "it goes without saying", "generally speaking",
+]
+
+INTENSIFIER = [
+    "very", "really", "quite", "extremely", "incredibly", "dramatically",
+    "significantly", "substantially", "highly", "vastly", "immensely",
+]
+
+CLOSER = [
+    "in summary", "in conclusion", "to summarize", "all in all",
+    "at the end of the day", "provides a foundation", "sets the stage",
+    "paves the way", "going forward", "the possibilities are endless",
+]
+
+# Participles that read as adjectives, not as a passive with a hidden actor.
+PASSIVE_OK = {
+    "based", "related", "unrelated", "required", "intended", "supposed",
+    "limited", "interested", "aware", "expected", "involved", "located",
+    "deprecated", "documented", "supported", "named", "called",
+}
+
+BE = r"(?:am|is|are|was|were|be|been|being)"
+PP_IRREG = (
+    r"(?:done|made|sent|read|built|kept|held|set|put|run|written|shown|given"
+    r"|taken|found|got|gotten|seen|known|thrown|drawn|left|lost|meant|sold)"
+)
+NOMINALIZATION = re.compile(
+    r"\b(?:perform(?:s|ed)?|conduct(?:s|ed)?|carry out|carries out"
+    r"|make use of|makes use of|take (?:a look|action))\b",
+    re.I,
+)
+NOMINAL_OF = re.compile(r"\b(\w{4,}(?:tion|ment|ance|ence))\s+of\b", re.I)
+
+FIX_HINT = {
+    "long_sentence": "split into one idea per sentence",
+    "long_paragraph": "one topic per paragraph",
+    "semicolon": "replace with a period and two sentences",
+    "contraction": "expand it",
+    "passive_voice": "name the actor and use active voice",
+    "ing_main_verb": "use a simple tense",
+    "nominalization": "use the verb directly",
+    "phrasal_verb": "use a single plain verb",
+    "banned_word": "use the short common word",
+    "marketing_adjective": "delete it or state a measured fact",
+    "hedge": "delete the hedge and state the fact",
+    "intensifier": "delete it or give the number",
+    "empty_closer": "delete it or replace it with a fact",
+}
+
+# --------------------------------------------------------------------------- #
+# Checks: name -> (default weight, default absolute cap or None)
+# --------------------------------------------------------------------------- #
+
+ALL_CHECKS = [
+    "long_sentence", "long_paragraph", "semicolon", "contraction",
+    "passive_voice", "ing_main_verb", "nominalization", "phrasal_verb",
+    "banned_word", "marketing_adjective", "hedge", "intensifier", "empty_closer",
+]
+
+DEFAULT_WEIGHTS = {
+    "long_sentence": 1.0,
+    "long_paragraph": 1.0,
+    "semicolon": 1.0,
+    "contraction": 0.5,
+    "passive_voice": 1.0,
+    "ing_main_verb": 0.5,
+    "nominalization": 1.0,
+    "phrasal_verb": 0.5,
+    "banned_word": 1.0,
+    "marketing_adjective": 1.5,
+    "hedge": 1.5,
+    "intensifier": 0.5,
+    "empty_closer": 1.5,
+}
+
+# Checks that are almost always right, even on a terse code comment.
+HIGH_SIGNAL = ["banned_word", "marketing_adjective", "hedge", "empty_closer"]
+
+PROFILES = {
+    # Whole-file documentation. Every check, rate-based enforcement.
+    "docs": {
+        "enabled": list(ALL_CHECKS),
+        "threshold": 2.0,
+        "min_words": 50,
+        "max_sentence_words": 25,
+        "max_paragraph_sentences": 6,
+        "max": {},
+    },
+    # Procedures, runbooks, error text. Tighter caps, no hedging allowed.
+    "strict": {
+        "enabled": list(ALL_CHECKS),
+        "threshold": 0.5,
+        "min_words": 30,
+        "max_sentence_words": 20,
+        "max_paragraph_sentences": 6,
+        "max": {"hedge": 0, "marketing_adjective": 0},
+    },
+    # Source-code comments. Comments are terse fragments, so sentence, paragraph
+    # and voice rules do not apply.
+    #
+    # Marketing words, hedges and empty closers carry an absolute cap: one of
+    # them in a comment is worth flagging however short the comment is. The
+    # banned-word list stays rate-based, because it spans everything from clear
+    # slop ("utilize") to words that read as ordinary English in a docstring
+    # ("ensure"). An absolute cap there fails normal code on its first commit,
+    # which is how a hook gets switched off.
+    "comments": {
+        "enabled": list(HIGH_SIGNAL),
+        "threshold": 2.0,
+        "min_words": 40,
+        "max_sentence_words": 30,
+        "max_paragraph_sentences": 0,
+        "max": {"marketing_adjective": 0, "hedge": 0, "empty_closer": 0},
+    },
+}
+
+# --------------------------------------------------------------------------- #
+# Language table for comment extraction
+# --------------------------------------------------------------------------- #
+
+
+class Syntax(object):
+    """Comment and string delimiters for one language family.
+
+    `docs` are extracted as prose. `strings` are skipped so that a quoted "//"
+    or "#" is never mistaken for a comment.
+    """
+
+    def __init__(self, lines=(), blocks=(), strings=('"', "'"), docs=()):
+        self.lines = list(lines)
+        self.blocks = list(blocks)
+        self.strings = list(strings)
+        self.docs = list(docs)
+
+
+HASH = Syntax(lines=["#"])
+SLASH = Syntax(lines=["//"], blocks=[("/*", "*/")])
+DASH = Syntax(lines=["--"], blocks=[("--[[", "]]")])
+SEMI = Syntax(lines=[";"])
+MARKUP = Syntax(blocks=[("<!--", "-->")], strings=['"', "'"])
+PYTHON = Syntax(lines=["#"], docs=['"""', "'''"])
+
+LANGUAGES = {
+    # hash comments
+    ".py": PYTHON, ".pyi": PYTHON,
+    ".sh": HASH, ".bash": HASH, ".zsh": HASH, ".fish": HASH,
+    ".rb": Syntax(lines=["#"], blocks=[("=begin", "=end")]),
+    ".pl": HASH, ".pm": HASH, ".r": HASH, ".jl": HASH, ".nim": HASH,
+    ".yaml": HASH, ".yml": HASH, ".toml": HASH, ".cfg": HASH, ".conf": HASH,
+    ".tf": Syntax(lines=["#", "//"], blocks=[("/*", "*/")]),
+    ".tfvars": HASH, ".dockerfile": HASH, ".mk": HASH, ".gitignore": HASH,
+    ".ex": HASH, ".exs": HASH, ".cr": HASH, ".coffee": HASH,
+    # slash comments
+    ".c": SLASH, ".h": SLASH, ".cpp": SLASH, ".cc": SLASH, ".hpp": SLASH,
+    ".cs": SLASH, ".java": SLASH, ".kt": SLASH, ".kts": SLASH, ".scala": SLASH,
+    ".js": SLASH, ".jsx": SLASH, ".mjs": SLASH, ".cjs": SLASH,
+    ".ts": SLASH, ".tsx": SLASH, ".go": SLASH, ".rs": SLASH, ".swift": SLASH,
+    ".php": Syntax(lines=["//", "#"], blocks=[("/*", "*/")]),
+    ".dart": SLASH, ".proto": SLASH, ".groovy": SLASH, ".gradle": SLASH,
+    ".css": Syntax(blocks=[("/*", "*/")]), ".scss": SLASH, ".less": SLASH,
+    ".m": SLASH, ".mm": SLASH, ".zig": SLASH, ".v": SLASH,
+    # dash comments
+    ".sql": Syntax(lines=["--"], blocks=[("/*", "*/")]),
+    ".lua": DASH, ".hs": Syntax(lines=["--"], blocks=[("{-", "-}")]),
+    ".elm": DASH, ".ada": Syntax(lines=["--"]), ".vhd": Syntax(lines=["--"]),
+    # semicolon comments
+    ".lisp": SEMI, ".el": SEMI, ".clj": SEMI, ".cljs": SEMI, ".scm": SEMI,
+    ".ini": Syntax(lines=[";", "#"]), ".asm": SEMI, ".s": SEMI,
+    # markup
+    ".html": MARKUP, ".htm": MARKUP, ".xml": MARKUP, ".svg": MARKUP,
+    ".vue": MARKUP, ".xhtml": MARKUP,
+    # other
+    ".erl": Syntax(lines=["%"]), ".tex": Syntax(lines=["%"]),
+    ".ps1": Syntax(lines=["#"], blocks=[("<#", "#>")]),
+    ".bat": Syntax(lines=["REM ", "::"]), ".vim": Syntax(lines=['"']),
+}
+
+DOC_EXTENSIONS = {".md", ".markdown", ".mdx", ".rst", ".txt", ".adoc", ".org"}
+
+# Filenames without a useful extension.
+BY_NAME = {
+    "Dockerfile": HASH, "Makefile": HASH, "Rakefile": HASH, "Gemfile": HASH,
+    "Jenkinsfile": SLASH, "Vagrantfile": HASH, "Brewfile": HASH,
+    "README": None, "LICENSE": None,
+}
+
+# --------------------------------------------------------------------------- #
+# Extraction
+# --------------------------------------------------------------------------- #
+
+
+class Segment(object):
+    """One run of prose with the source line its first character sits on."""
+
+    def __init__(self, line, text, kind="prose"):
+        self.line = line
+        self.text = text
+        self.kind = kind
+
+
+def _skip_string(text, i, line, quote):
+    """Advance past a string literal, honouring backslash escapes."""
+    n = len(text)
+    i += len(quote)
+    while i < n:
+        if text[i] == "\\":
+            if text[i:i + 2] == "\\\n":
+                line += 1
+            i += 2
+            continue
+        if text.startswith(quote, i):
+            return i + len(quote), line
+        if text[i] == "\n":
+            line += 1
+            # An unterminated single-char quote is far more likely an apostrophe
+            # than a string, so stop at the newline rather than eating the file.
+            if len(quote) == 1:
+                return i + 1, line
+        i += 1
+    return n, line
+
+
+def extract_comments(text, syntax):
+    """Return comment segments from source code, in file order."""
+    out = []
+    i, line, n = 0, 1, len(text)
+
+    # A shebang is machine configuration, not prose.
+    if text.startswith("#!"):
+        i = text.find("\n")
+        if i == -1:
+            return out
+        i += 1
+        line = 2
+
+    while i < n:
+        if text[i] == "\n":
+            line += 1
+            i += 1
+            continue
+
+        matched = False
+
+        # Docstrings first: in Python a triple-quoted string is documentation.
+        for token in syntax.docs:
+            if text.startswith(token, i):
+                end = text.find(token, i + len(token))
+                if end == -1:
+                    end = n
+                body = text[i + len(token):end]
+                out.append(Segment(line, body, "block"))
+                line += text.count("\n", i, min(end + len(token), n))
+                i = min(end + len(token), n)
+                matched = True
+                break
+        if matched:
+            continue
+
+        for quote in syntax.strings:
+            if text.startswith(quote, i):
+                i, line = _skip_string(text, i, line, quote)
+                matched = True
+                break
+        if matched:
+            continue
+
+        for open_token, close_token in syntax.blocks:
+            if text.startswith(open_token, i):
+                end = text.find(close_token, i + len(open_token))
+                if end == -1:
+                    end = n
+                body = text[i + len(open_token):end]
+                out.append(Segment(line, body, "block"))
+                line += text.count("\n", i, min(end + len(close_token), n))
+                i = min(end + len(close_token), n)
+                matched = True
+                break
+        if matched:
+            continue
+
+        for token in syntax.lines:
+            if text.startswith(token, i):
+                end = text.find("\n", i)
+                if end == -1:
+                    end = n
+                out.append(Segment(line, text[i + len(token):end], "line"))
+                i = end
+                matched = True
+                break
+        if matched:
+            continue
+
+        i += 1
+    return out
+
+
+BLOCK_ORNAMENT = re.compile(r"^\s*[*!/#=\-]+\s?")
+DIRECTIVE = re.compile(
+    r"^\s*(?:@\w+|:\w+:|\w+:\/\/|(?:type|param|returns?|raises?|yields?|arg|args|"
+    r"attribute|attributes|note|todo|fixme|noqa|pylint|eslint|prettier|ruff|mypy|"
+    r"pragma|see|since|deprecated|example|examples|usage)\b[\s:])",
+    re.I,
+)
+
+
+def group_line_comments(segments):
+    """Group runs of contiguous single-line comments.
+
+    Returns a list of (kind, parts), where parts is a list of (line, text). A
+    sentence is often wrapped across several consecutive comment lines, so the
+    run has to be rejoined before sentence checks can see it. Parts keep their
+    own line numbers so that findings and ignore markers stay line-accurate.
+    """
+    groups = []
+    current = None
+    last_line = None
+    for seg in segments:
+        if seg.kind == "block":
+            if current:
+                groups.append(("line", current))
+                current, last_line = None, None
+            parts = [(seg.line + offset, part)
+                     for offset, part in enumerate(seg.text.split("\n"))]
+            groups.append(("block", parts))
+            continue
+        if current is not None and last_line is not None and seg.line == last_line + 1:
+            current.append((seg.line, seg.text))
+        else:
+            if current:
+                groups.append(("line", current))
+            current = [(seg.line, seg.text)]
+        last_line = seg.line
+    if current:
+        groups.append(("line", current))
+    return groups
+
+
+# markdown handling
+FENCE = re.compile(r"^\s{0,3}(?:```|~~~)")
+HEADING = re.compile(r"^\s{0,3}(#{1,6})\s+(.*)$")
+LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+")
+TABLE_ROW = re.compile(r"^\s*\|.*\|\s*$")
+HRULE = re.compile(r"^\s{0,3}(?:-{3,}|\*{3,}|_{3,})\s*$")
+RST_DIRECTIVE = re.compile(r"^\s*\.\.\s")
+IGNORE_LINE = re.compile(r"(?:<!--|#|//)\s*prose-lint:\s*ignore\s*(?:-->)?")
+IGNORE_START = re.compile(r"(?:<!--|#|//)\s*prose-lint:\s*ignore-start\s*(?:-->)?")
+IGNORE_END = re.compile(r"(?:<!--|#|//)\s*prose-lint:\s*ignore-end\s*(?:-->)?")
+
+
+def mask_inline(text):
+    """Remove spans that are code or addresses, not prose."""
+    text = re.sub(r"``[^`]*``|`[^`]*`", " CODE ", text)
+    text = re.sub(r"!\[[^\]]*\]\([^)]*\)", " IMAGE ", text)
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
+    text = re.sub(r"\[\[[^\]|]*\|([^\]]*)\]\]", r"\1", text)
+    text = re.sub(r"\[\[([^\]]*)\]\]", r"\1", text)
+    text = re.sub(r"<https?://[^>]*>|https?://\S+", " URL ", text)
+    text = re.sub(r"<!--.*?-->", " ", text)
+    text = re.sub(r"<[^>]{1,40}>", " ", text)
+    return text
+
+
+def structural_lines(src):
+    """Line numbers that are frontmatter or fenced code, and lines the ignore
+    markers suppress.
+
+    Fence and frontmatter state must resolve before anything else can skip a
+    line, otherwise a skipped fence marker inverts the fence state and swallows
+    the rest of the file.
+    """
+    structural = set()
+    in_fence = False
+    in_frontmatter = src[:1] == ["---"]
+    for i, text in enumerate(src, start=1):
+        if in_frontmatter:
+            structural.add(i)
+            if i > 1 and text.strip() in ("---", "..."):
+                in_frontmatter = False
+            continue
+        if FENCE.match(text):
+            in_fence = not in_fence
+            structural.add(i)
+            continue
+        if in_fence:
+            structural.add(i)
+
+    ignored = set()
+    block, marked, in_region = [], False, False
+    for i, text in enumerate(src, start=1):
+        if i in structural:
+            continue
+        if IGNORE_START.search(text):
+            in_region = True
+        if in_region:
+            ignored.add(i)
+            if IGNORE_END.search(text):
+                in_region = False
+            continue
+        if text.strip():
+            block.append(i)
+            marked = marked or bool(IGNORE_LINE.search(text))
+        else:
+            if marked:
+                ignored.update(block)
+            block, marked = [], False
+    if marked:
+        ignored.update(block)
+    return structural, ignored
+
+
+def extract_document(text):
+    """Return paragraph blocks for a documentation file.
+
+    Each block is a list of units. A unit is one logical sentence run, rejoined
+    from however many source lines it was hard-wrapped across.
+    """
+    src = text.split("\n")
+    structural, ignored = structural_lines(src)
+    blocks, block = [], []
+
+    for i, raw in enumerate(src, start=1):
+        skip = (
+            i in structural
+            or i in ignored
+            or HRULE.match(raw)
+            or RST_DIRECTIVE.match(raw)
+            or (raw.strip() and raw.startswith("    ") and not LIST_ITEM.match(raw))
+        )
+        masked = mask_inline(raw)
+        if skip or not masked.strip():
+            if block:
+                blocks.append(block)
+                block = []
+            continue
+
+        if HEADING.match(raw):
+            if block:
+                blocks.append(block)
+                block = []
+            heading = HEADING.match(masked)
+            blocks.append([Segment(i, heading.group(2) if heading else masked, "heading")])
+            continue
+        if TABLE_ROW.match(raw):
+            if block:
+                blocks.append(block)
+                block = []
+            blocks.append([Segment(i, masked.replace("|", " "), "table")])
+            continue
+
+        if LIST_ITEM.match(raw):
+            block.append(Segment(i, LIST_ITEM.sub("", masked), "list"))
+        elif raw.lstrip().startswith(">"):
+            block.append(Segment(i, masked.lstrip().lstrip(">").strip(), "quote"))
+        elif block and block[-1].kind in ("list", "quote"):
+            block[-1].text += " " + masked.strip()
+        elif block and block[-1].kind == "prose":
+            block[-1].text += " " + masked.strip()
+        else:
+            block.append(Segment(i, masked.strip(), "prose"))
+
+    if block:
+        blocks.append(block)
+    return blocks
+
+
+def extract_comment_blocks(text, syntax):
+    """Return paragraph blocks for a source file, from its comments only."""
+    raw_segments = extract_comments(text, syntax)
+    src = text.split("\n")
+    _, ignored = structural_lines(src)
+    units = []
+    for kind, parts in group_line_comments(raw_segments):
+        # Parts keep their own line numbers, so an ignore marker anywhere inside
+        # a multi-line comment suppresses only the lines it covers.
+        if kind == "block":
+            parts = [(line, BLOCK_ORNAMENT.sub("", part).strip())
+                     for line, part in parts]
+        else:
+            parts = [(line, part.strip()) for line, part in parts]
+        parts = [(line, part) for line, part in parts
+                 if part and line not in ignored and not DIRECTIVE.match(part)]
+        if not parts:
+            continue
+        joined = mask_inline(" ".join(part for _, part in parts)).strip()
+        if joined:
+            units.append(Segment(parts[0][0], joined, "comment"))
+    return [[unit] for unit in units]
+
+# --------------------------------------------------------------------------- #
+# Checks
+# --------------------------------------------------------------------------- #
+
+SENT_SPLIT = re.compile(r"(?<=[.!?])\s+(?=[A-Z0-9\"'(])")
+WORD = re.compile(r"[A-Za-z0-9][A-Za-z0-9'\-/]*")
+
+
+def sentences(text):
+    return [p.strip() for p in SENT_SPLIT.split(text) if p.strip()]
+
+
+def word_count(text):
+    return len(WORD.findall(text))
+
+
+def excerpt(text, width=68):
+    text = " ".join(text.split())
+    return text if len(text) <= width else text[:width - 1] + "..."
+
+
+def find_phrases(text, phrases):
+    """Return (phrase, suggestion) for each occurrence, case-insensitively."""
+    hits = []
+    low = text.lower()
+    items = phrases.items() if isinstance(phrases, dict) else [(p, None) for p in phrases]
+    for phrase, suggestion in items:
+        pattern = r"(?<![a-z])" + re.escape(phrase.lower()) + r"(?![a-z])"
+        for _ in re.finditer(pattern, low):
+            hits.append((phrase, suggestion))
+    return hits
+
+
+class Finding(object):
+    def __init__(self, line, check, detail, excerpt_text=""):
+        self.line = line
+        self.check = check
+        self.detail = detail
+        self.excerpt = excerpt_text
+
+
+def run_checks(blocks, cfg):
+    """Apply every enabled check. Returns a list of Findings."""
+    out = []
+    enabled = cfg["enabled"]
+    banned = cfg["banned"]
+    marketing = cfg["marketing"]
+
+    def add(line, check, detail, text=""):
+        if check in enabled:
+            out.append(Finding(line, check, detail, excerpt(text)))
+
+    for block in blocks:
+        sentence_total = 0
+        for unit in block:
+            text = unit.text
+            line = unit.line
+
+            # Sentence length: skip headings and table cells, which are fragments.
+            if unit.kind not in ("heading", "table"):
+                for sentence in sentences(text):
+                    sentence_total += 1
+                    length = word_count(sentence)
+                    if length > cfg["max_sentence_words"]:
+                        add(line, "long_sentence",
+                            "%d words (max %d)" % (length, cfg["max_sentence_words"]),
+                            sentence)
+
+            for _ in re.finditer(r";", text):
+                add(line, "semicolon", "semicolon", text)
+
+            for match in re.finditer(r"\b\w+['’](?:t|re|ve|ll|d|s|m)\b", text):
+                word = match.group(0)
+                if word.lower().endswith(("'s", "’s")):
+                    continue
+                add(line, "contraction", word, text)
+
+            for match in re.finditer(r"\b(%s)\s+(\w+ed|%s)\b" % (BE, PP_IRREG), text, re.I):
+                if match.group(2).lower() in PASSIVE_OK:
+                    continue
+                add(line, "passive_voice", match.group(0), text)
+
+            for match in re.finditer(r"\b%s\s+(\w+ing)\b" % BE, text, re.I):
+                add(line, "ing_main_verb", match.group(0), text)
+
+            for match in NOMINALIZATION.finditer(text):
+                add(line, "nominalization", match.group(0), text)
+            for match in NOMINAL_OF.finditer(text):
+                add(line, "nominalization", "%s of" % match.group(1), text)
+
+            for phrase, suggestion in find_phrases(text, PHRASAL):
+                add(line, "phrasal_verb", '"%s" -> %s' % (phrase, suggestion), text)
+
+            for phrase, suggestion in find_phrases(text, banned):
+                fix = "-> %s" % suggestion if suggestion else "-> delete"
+                add(line, "banned_word", '"%s" %s' % (phrase, fix), text)
+
+            for phrase, _ in find_phrases(text, marketing):
+                add(line, "marketing_adjective", '"%s"' % phrase, text)
+
+            for phrase, _ in find_phrases(text, HEDGE):
+                add(line, "hedge", '"%s"' % phrase, text)
+
+            for phrase, _ in find_phrases(text, INTENSIFIER):
+                add(line, "intensifier", '"%s"' % phrase, text)
+
+            for phrase, _ in find_phrases(text, CLOSER):
+                add(line, "empty_closer", '"%s"' % phrase, text)
+
+        cap = cfg["max_paragraph_sentences"]
+        if cap and sentence_total > cap and not any(
+                u.kind in ("list", "heading", "table") for u in block):
+            add(block[0].line, "long_paragraph",
+                "%d sentences (max %d)" % (sentence_total, cap), block[0].text)
+
+    out.sort(key=lambda f: (f.line, f.check))
+    return out
+
+# --------------------------------------------------------------------------- #
+# Configuration
+# --------------------------------------------------------------------------- #
+
+
+def build_config(args):
+    """Merge profile defaults, JSON config and CLI overrides, in that order."""
+    raw = {}
+    if args.config:
+        if os.path.isfile(args.config):
+            with open(args.config) as handle:
+                raw = json.load(handle)
+        else:
+            try:
+                raw = json.loads(args.config)
+            except ValueError as exc:
+                raise ConfigError("--config is neither a readable file "
+                                 "nor valid JSON (%s)" % exc)
+    if not isinstance(raw, dict):
+        raise ConfigError("--config must be a JSON object")
+
+    profile_name = args.profile or raw.get("profile") or "docs"
+    if profile_name not in PROFILES:
+        raise ConfigError("unknown profile %r (choose from %s)"
+                         % (profile_name, ", ".join(sorted(PROFILES))))
+    profile = PROFILES[profile_name]
+
+    cfg = {
+        "profile": profile_name,
+        "threshold": profile["threshold"],
+        "min_words": profile["min_words"],
+        "max_sentence_words": profile["max_sentence_words"],
+        "max_paragraph_sentences": profile["max_paragraph_sentences"],
+        "weights": dict(DEFAULT_WEIGHTS),
+        "max": dict(profile["max"]),
+        "enabled": set(profile["enabled"]),
+    }
+
+    for key in ("threshold", "min_words", "max_sentence_words",
+                "max_paragraph_sentences"):
+        if key in raw:
+            cfg[key] = raw[key]
+
+    for name, spec in (raw.get("checks") or {}).items():
+        if name not in ALL_CHECKS:
+            raise ConfigError("unknown check %r in config (choose from %s)"
+                             % (name, ", ".join(ALL_CHECKS)))
+        if not isinstance(spec, dict):
+            raise ConfigError("config for check %r must be an object" % name)
+        if spec.get("enabled") is True:
+            cfg["enabled"].add(name)
+        elif spec.get("enabled") is False:
+            cfg["enabled"].discard(name)
+        if "weight" in spec:
+            cfg["weights"][name] = float(spec["weight"])
+        if "max" in spec:
+            cfg["max"][name] = None if spec["max"] is None else int(spec["max"])
+
+    # CLI overrides win over the JSON config.
+    if args.threshold is not None:
+        cfg["threshold"] = args.threshold
+    if args.min_words is not None:
+        cfg["min_words"] = args.min_words
+    if args.max_sentence_words is not None:
+        cfg["max_sentence_words"] = args.max_sentence_words
+    if args.max_paragraph_sentences is not None:
+        cfg["max_paragraph_sentences"] = args.max_paragraph_sentences
+
+    for name in args.enable or []:
+        if name not in ALL_CHECKS:
+            raise ConfigError("unknown check %r" % name)
+        cfg["enabled"].add(name)
+    for name in args.disable or []:
+        if name not in ALL_CHECKS:
+            raise ConfigError("unknown check %r" % name)
+        cfg["enabled"].discard(name)
+    for item in args.weight or []:
+        name, _, value = item.partition("=")
+        if name not in ALL_CHECKS or not value:
+            raise ConfigError("--weight expects CHECK=NUMBER, got %r" % item)
+        cfg["weights"][name] = float(value)
+    for item in args.max or []:
+        name, _, value = item.partition("=")
+        if name not in ALL_CHECKS or not value:
+            raise ConfigError("--max expects CHECK=INTEGER, got %r" % item)
+        cfg["max"][name] = int(value)
+
+    # Project vocabulary.
+    banned = dict(BANNED)
+    banned.update(raw.get("extra_banned") or {})
+    marketing = list(MARKETING) + list(raw.get("extra_marketing") or [])
+    allow = set(word.lower() for word in (raw.get("allow") or []))
+    allow.update(word.lower() for word in (args.allow or []))
+    for word in allow:
+        banned.pop(word, None)
+    marketing = [word for word in marketing if word.lower() not in allow]
+
+    cfg["banned"] = banned
+    cfg["marketing"] = marketing
+    cfg["allow"] = allow
+    return cfg
+
+# --------------------------------------------------------------------------- #
+# Scoring and reporting
+# --------------------------------------------------------------------------- #
+
+
+def score(findings, words, cfg):
+    """Weighted violations per 100 words, plus per-check counts."""
+    counts = {}
+    weighted = 0.0
+    for finding in findings:
+        counts[finding.check] = counts.get(finding.check, 0) + 1
+        weighted += cfg["weights"].get(finding.check, 1.0)
+    rate = round(weighted * 100.0 / words, 2) if words else 0.0
+    return counts, round(weighted, 2), rate
+
+
+def evaluate(path, text, cfg, kind, syntax):
+    if kind == "doc":
+        blocks = extract_document(text)
+    else:
+        blocks = extract_comment_blocks(text, syntax)
+
+    words = sum(word_count(unit.text) for block in blocks for unit in block)
+    findings = run_checks(blocks, cfg)
+    counts, weighted, rate = score(findings, words, cfg)
+
+    reasons = []
+    for name, cap in sorted(cfg["max"].items()):
+        if cap is None or name not in cfg["enabled"]:
+            continue
+        found = counts.get(name, 0)
+        if found > cap:
+            reasons.append("%s: %d found, max %d" % (name, found, cap))
+
+    over_threshold = rate > cfg["threshold"]
+    if words < cfg["min_words"]:
+        # Rate-based scoring is noise on very short prose: a single violation in
+        # a 12-word comment reads as 8 per 100 words. Absolute caps still apply.
+        over_threshold = False
+    if over_threshold:
+        reasons.append("score %.2f per 100 words, max %.2f" % (rate, cfg["threshold"]))
+
+    return {
+        "path": path,
+        "kind": kind,
+        "words": words,
+        "findings": findings,
+        "counts": counts,
+        "weighted": weighted,
+        "rate": rate,
+        "reasons": reasons,
+        "passed": not reasons,
+    }
+
+
+def err(message):
+    """Print a string to stderr."""
+    print(message, file=sys.stderr)
+
+
+class ConfigError(Exception):
+    """Bad configuration or usage. Reported with exit code 2, not 1, so that a
+    caller can tell a misconfigured hook from prose that failed the budget."""
+
+
+def report(result, quiet):
+    for finding in result["findings"]:
+        hint = FIX_HINT.get(finding.check, "")
+        err("%s:%d: %s: %s%s" % (result["path"], finding.line, finding.check,
+                                 finding.detail, " (%s)" % hint if hint else ""))
+        if finding.excerpt and not quiet:
+            err("    %s" % finding.excerpt)
+    for reason in result["reasons"]:
+        err("%s: FAIL %s" % (result["path"], reason))
+
+
+def classify(path, include_unknown):
+    """Return (kind, syntax) for a path, or (None, None) when unsupported."""
+    name = os.path.basename(path)
+    ext = os.path.splitext(name)[1].lower()
+    if ext in DOC_EXTENSIONS:
+        return "doc", None
+    if ext in LANGUAGES:
+        return "code", LANGUAGES[ext]
+    if name in BY_NAME and BY_NAME[name] is not None:
+        return "code", BY_NAME[name]
+    if not ext and include_unknown:
+        return "doc", None
+    return None, None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Lint prose in documentation and source-code comments.")
+    parser.add_argument("filenames", nargs="*")
+    parser.add_argument("--profile", choices=sorted(PROFILES), default=None,
+                        help="rule preset (default: docs)")
+    parser.add_argument("--config", default=None,
+                        help="JSON config, as an inline string or a file path")
+    parser.add_argument("--threshold", type=float, default=None,
+                        help="maximum weighted violations per 100 words")
+    parser.add_argument("--min-words", type=int, default=None, dest="min_words",
+                        help="below this word count, only absolute caps apply")
+    parser.add_argument("--max-sentence-words", type=int, default=None,
+                        dest="max_sentence_words")
+    parser.add_argument("--max-paragraph-sentences", type=int, default=None,
+                        dest="max_paragraph_sentences")
+    parser.add_argument("--enable", action="append", metavar="CHECK")
+    parser.add_argument("--disable", action="append", metavar="CHECK")
+    parser.add_argument("--weight", action="append", metavar="CHECK=NUMBER")
+    parser.add_argument("--max", action="append", metavar="CHECK=INTEGER")
+    parser.add_argument("--allow", action="append", metavar="WORD",
+                        help="drop a word from the banned and marketing lists")
+    parser.add_argument("--exclude", action="append", metavar="GLOB",
+                        help="skip paths matching this glob")
+    parser.add_argument("--include-unknown", action="store_true",
+                        help="treat extensionless files as documentation")
+    parser.add_argument("--warn-only", action="store_true",
+                        help="report findings as warnings and exit 0")
+    parser.add_argument("--quiet", action="store_true",
+                        help="omit the quoted excerpt under each finding")
+    parser.add_argument("--json", action="store_true", dest="as_json",
+                        help="emit machine-readable results")
+    parser.add_argument("--list-checks", action="store_true",
+                        help="print the checks with default weights and exit")
+
+    # Allow pre-commit try-repo to pass in additional arguments
+    if os.environ.get("PRE_COMMIT_TRY_ARGS"):
+        sys.argv.extend(shlex.split(os.environ["PRE_COMMIT_TRY_ARGS"]))
+
+    args = parser.parse_args()
+
+    if args.list_checks:
+        print("%-22s %-8s %s" % ("check", "weight", "profiles"))
+        for name in ALL_CHECKS:
+            profiles = ",".join(sorted(key for key, value in PROFILES.items()
+                                       if name in value["enabled"]))
+            print("%-22s %-8.1f %s" % (name, DEFAULT_WEIGHTS[name], profiles))
+        return 0
+
+    try:
+        cfg = build_config(args)
+    except ConfigError as exc:
+        err("prose-lint: %s" % exc)
+        return 2
+    results = []
+    for path in args.filenames:
+        if any(fnmatch.fnmatch(path, pattern) for pattern in args.exclude or []):
+            continue
+        kind, syntax = classify(path, args.include_unknown)
+        if kind is None:
+            continue
+        try:
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                text = handle.read()
+        except (IOError, OSError) as exc:
+            err("%s: cannot read (%s)" % (path, exc))
+            return 2
+        results.append(evaluate(path, text, cfg, kind, syntax))
+
+    if args.as_json:
+        print(json.dumps([{
+            "path": r["path"], "kind": r["kind"], "words": r["words"],
+            "weighted": r["weighted"], "rate": r["rate"], "passed": r["passed"],
+            "counts": r["counts"], "reasons": r["reasons"],
+            "findings": [{"line": f.line, "check": f.check, "detail": f.detail,
+                          "excerpt": f.excerpt} for f in r["findings"]],
+        } for r in results], indent=2))
+    else:
+        for result in results:
+            if not result["passed"] or (args.warn_only and result["findings"]):
+                report(result, args.quiet)
+
+    failed = [r for r in results if not r["passed"]]
+    if failed and args.warn_only:
+        err("prose-lint: %d file(s) over budget, not blocking (--warn-only)"
+            % len(failed))
+        return 0
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prose_lint.py
+++ b/prose_lint.py
@@ -375,12 +375,38 @@ BY_NAME = {
 
 
 class Segment(object):
-    """One run of prose with the source line its first character sits on."""
+    """One run of prose, rejoined from however many source lines it was wrapped
+    across, with the map back to those lines.
 
-    def __init__(self, line, text, kind="prose"):
+    `parts` holds every source line the text was joined from, so a finding's
+    character offset resolves to the line that actually contains it. Without the
+    map every finding in a paragraph reports the paragraph's first line, which
+    for a hook whose entire output is `file:line` reads as a broken tool.
+
+    `text` must stay equal to " ".join(part for _, part in parts), because the
+    offsets in `line_of` are offsets into `text`. Use `extend` rather than
+    appending to `text` directly.
+    """
+
+    def __init__(self, line, text, kind="prose", parts=None):
         self.line = line
         self.text = text
         self.kind = kind
+        self.parts = list(parts) if parts else [(line, text)]
+
+    def extend(self, line, text):
+        """Append a wrapped continuation line, keeping the offset map intact."""
+        self.text += " " + text
+        self.parts.append((line, text))
+
+    def line_of(self, offset):
+        """Map a character offset in `text` back to its source line."""
+        pos = 0
+        for line, part in self.parts:
+            if offset <= pos + len(part):
+                return line
+            pos += len(part) + 1
+        return self.line
 
 
 def _skip_string(text, i, line, quote):
@@ -745,9 +771,9 @@ def extract_document(text):
         elif raw.lstrip().startswith(">"):
             block.append(Segment(i, masked.lstrip().lstrip(">").strip(), "quote"))
         elif block and block[-1].kind in ("list", "quote"):
-            block[-1].text += " " + masked.strip()
+            block[-1].extend(i, masked.strip())
         elif block and block[-1].kind == "prose":
-            block[-1].text += " " + masked.strip()
+            block[-1].extend(i, masked.strip())
         else:
             block.append(Segment(i, masked.strip(), "prose"))
 
@@ -774,14 +800,16 @@ def extract_comment_blocks(text, syntax):
                      for line, part in parts]
         else:
             parts = [(line, part.strip()) for line, part in parts]
-        parts = [(line, strip_directive(part)) for line, part in parts
-                 if line not in ignored]
+        # Masking runs per line here, as it already does on the document path, so
+        # that a finding's offset still resolves through Segment.line_of.
+        parts = [(line, mask_inline(strip_directive(part)).strip())
+                 for line, part in parts if line not in ignored]
         parts = [(line, part) for line, part in parts if part]
         if not parts:
             continue
-        joined = mask_inline(" ".join(part for _, part in parts)).strip()
-        if joined:
-            units.append(Segment(parts[0][0], joined, "comment"))
+        joined = " ".join(part for _, part in parts)
+        if joined.strip():
+            units.append(Segment(parts[0][0], joined, "comment", parts))
     return [[unit] for unit in units]
 
 # --------------------------------------------------------------------------- #
@@ -824,14 +852,18 @@ def excerpt(text, width=68):
 
 
 def find_phrases(text, phrases):
-    """Return (phrase, suggestion) for each occurrence, case-insensitively."""
+    """Return (phrase, suggestion, offset) per occurrence, case-insensitively.
+
+    The offset is what lets a finding name the line holding the phrase rather
+    than the first line of the paragraph it was joined into.
+    """
     hits = []
     low = text.lower()
     items = phrases.items() if isinstance(phrases, dict) else [(p, None) for p in phrases]
     for phrase, suggestion in items:
         pattern = r"(?<![a-z])" + re.escape(phrase.lower()) + r"(?![a-z])"
-        for _ in re.finditer(pattern, low):
-            hits.append((phrase, suggestion))
+        for match in re.finditer(pattern, low):
+            hits.append((phrase, suggestion, match.start()))
     return hits
 
 
@@ -850,74 +882,83 @@ def run_checks(blocks, cfg):
     banned = cfg["banned"]
     marketing = cfg["marketing"]
 
-    def add(line, check, detail, text=""):
+    def add(unit, offset, check, detail, text=""):
+        # The offset is resolved against the unit rather than stored, so a
+        # finding names the source line holding the text it quotes.
         if check in enabled:
-            out.append(Finding(line, check, detail, excerpt(text)))
+            out.append(Finding(unit.line_of(offset), check, detail, excerpt(text)))
 
     for block in blocks:
         sentence_total = 0
         for unit in block:
             text = unit.text
-            line = unit.line
 
             # Sentence length: skip headings and table cells, which are fragments.
             if unit.kind not in ("heading", "table"):
+                cursor = 0
                 for sentence in sentences(text):
                     sentence_total += 1
+                    found = text.find(sentence, cursor)
+                    if found >= 0:
+                        cursor = found + len(sentence)
                     length = word_count(sentence)
                     if length > cfg["max_sentence_words"]:
-                        add(line, "long_sentence",
+                        add(unit, found if found >= 0 else 0, "long_sentence",
                             "%d words (max %d)" % (length, cfg["max_sentence_words"]),
                             sentence)
 
-            for _ in re.finditer(r";", text):
-                add(line, "semicolon", "semicolon", text)
+            for match in re.finditer(r";", text):
+                add(unit, match.start(), "semicolon", "semicolon", text)
 
             for match in re.finditer(r"\b\w+['’](?:t|re|ve|ll|d|s|m)\b", text):
                 word = match.group(0)
                 norm = word.lower().replace("’", "'")
                 if norm.endswith("'s") and norm not in S_CONTRACTIONS:
                     continue                    # possessive, not a contraction
-                add(line, "contraction", word, text)
+                add(unit, match.start(), "contraction", word, text)
 
             for match in re.finditer(r"\b(%s)\s+(\w+ed|%s)\b" % (BE, PP_IRREG), text, re.I):
                 if match.group(2).lower() in PASSIVE_OK:
                     continue
-                add(line, "passive_voice", match.group(0), text)
+                add(unit, match.start(), "passive_voice", match.group(0), text)
 
             for match in re.finditer(r"\b%s\s+(\w+ing)\b" % BE, text, re.I):
                 if match.group(1).lower() in ING_NOUN:
                     continue                            # a noun, not a verb
-                add(line, "ing_main_verb", match.group(0), text)
+                add(unit, match.start(), "ing_main_verb", match.group(0), text)
 
             for match in NOMINALIZATION.finditer(text):
-                add(line, "nominalization", match.group(0), text)
+                add(unit, match.start(), "nominalization", match.group(0), text)
             for match in NOMINAL_OF.finditer(text):
-                add(line, "nominalization", "%s of" % match.group(1), text)
+                add(unit, match.start(), "nominalization",
+                    "%s of" % match.group(1), text)
 
-            for phrase, suggestion in find_phrases(text, PHRASAL):
-                add(line, "phrasal_verb", '"%s" -> %s' % (phrase, suggestion), text)
+            for phrase, suggestion, at in find_phrases(text, PHRASAL):
+                add(unit, at, "phrasal_verb",
+                    '"%s" -> %s' % (phrase, suggestion), text)
 
-            for phrase, suggestion in find_phrases(text, banned):
+            for phrase, suggestion, at in find_phrases(text, banned):
                 fix = "-> %s" % suggestion if suggestion else "-> delete"
-                add(line, "banned_word", '"%s" %s' % (phrase, fix), text)
+                add(unit, at, "banned_word", '"%s" %s' % (phrase, fix), text)
 
-            for phrase, _ in find_phrases(text, marketing):
-                add(line, "marketing_adjective", '"%s"' % phrase, text)
+            for phrase, _, at in find_phrases(text, marketing):
+                add(unit, at, "marketing_adjective", '"%s"' % phrase, text)
 
-            for phrase, _ in find_phrases(text, HEDGE):
-                add(line, "hedge", '"%s"' % phrase, text)
+            for phrase, _, at in find_phrases(text, HEDGE):
+                add(unit, at, "hedge", '"%s"' % phrase, text)
 
-            for phrase, _ in find_phrases(text, INTENSIFIER):
-                add(line, "intensifier", '"%s"' % phrase, text)
+            for phrase, _, at in find_phrases(text, INTENSIFIER):
+                add(unit, at, "intensifier", '"%s"' % phrase, text)
 
-            for phrase, _ in find_phrases(text, CLOSER):
-                add(line, "empty_closer", '"%s"' % phrase, text)
+            for phrase, _, at in find_phrases(text, CLOSER):
+                add(unit, at, "empty_closer", '"%s"' % phrase, text)
 
         cap = cfg["max_paragraph_sentences"]
         if cap and sentence_total > cap and not any(
                 u.kind in ("list", "heading", "table") for u in block):
-            add(block[0].line, "long_paragraph",
+            # A paragraph rule is a fact about the whole block, so it belongs on
+            # the block's first line rather than on any one offset inside it.
+            add(block[0], 0, "long_paragraph",
                 "%d sentences (max %d)" % (sentence_total, cap), block[0].text)
 
     out.sort(key=lambda f: (f.line, f.check))

--- a/prose_lint.py
+++ b/prose_lint.py
@@ -1283,7 +1283,11 @@ class ConfigError(Exception):
     caller can tell a misconfigured hook from prose that failed the budget."""
 
 
-def report(result, quiet):
+def report(result, quiet, warn_only=False):
+    # Under --warn-only nothing is failing, so the per-file line says WARN. A
+    # report that prints "FAIL" and then "not blocking" contradicts itself on one
+    # screen, and a reader has to know which half to believe.
+    label = "WARN" if warn_only else "FAIL"
     for finding in result["findings"]:
         hint = FIX_HINT.get(finding.check, "")
         err("%s:%d: %s: %s%s" % (result["path"], finding.line, finding.check,
@@ -1291,7 +1295,7 @@ def report(result, quiet):
         if finding.excerpt and not quiet:
             err("    %s" % finding.excerpt)
     for reason in result["reasons"]:
-        err("%s: FAIL %s" % (result["path"], reason))
+        err("%s: %s %s" % (result["path"], label, reason))
 
 
 def classify(path, include_unknown):
@@ -1403,7 +1407,7 @@ def main():
     else:
         for result in results:
             if not result["passed"] or (args.warn_only and result["findings"]):
-                report(result, args.quiet)
+                report(result, args.quiet, args.warn_only)
         if args.total:
             print_totals(totals(results), cfg)
 

--- a/prose_lint.py
+++ b/prose_lint.py
@@ -529,12 +529,69 @@ def extract_python(text):
 
 
 BLOCK_ORNAMENT = re.compile(r"^\s*[*!/#=\-]+\s?")
-DIRECTIVE = re.compile(
-    r"^\s*(?:@\w+|:\w+:|\w+:\/\/|(?:type|param|returns?|raises?|yields?|arg|args|"
-    r"attribute|attributes|note|todo|fixme|noqa|pylint|eslint|prettier|ruff|mypy|"
-    r"pragma|see|since|deprecated|example|examples|usage)\b[\s:])",
+
+# Tool configuration rather than prose, so the whole line goes.
+SUPPRESS = re.compile(
+    r"^\s*(?:noqa|pylint|eslint|prettier|prettier-ignore|ruff|mypy|pyright|flake8"
+    r"|black|isort|fmt|type|pragma|coverage|ts-ignore|ts-expect-error"
+    r"|codegen|checkstyle|shellcheck|nolint|golangci)\b[\s:]",
     re.I,
 )
+
+# A documentation tag is a label on prose, so the tag goes and the description
+# stays. Dropping the whole line discarded 11.7% of all comment words measured
+# across 17 repos, 38% in one, and let a JSDoc block of pure marketing score 0.00.
+DOC_TAG = re.compile(
+    r"^\s*(?:@\w+|:\w+:|(?:param|returns?|raises?|yields?|arg|args|attribute"
+    r"|attributes|note|notes|see|since|deprecated|example|examples|usage|todo"
+    r"|fixme|warning|important)\b\s*:?)\s*",
+    re.I,
+)
+
+# A line holding nothing but an address carries no prose.
+URL_ONLY = re.compile(r"^\s*<?\w+://\S+>?\s*$")
+
+# "@param name - description": the name is an identifier, so it is not prose.
+TAG_OPERAND = re.compile(r"^[\w.\[\]*{}|<>]+\s*(?:-{1,2}|:)\s+")
+
+# A word that belongs to prose rather than to a command line: letters only, not
+# glued to a path separator, dot, digit or flag dash.
+PROSE_WORD = re.compile(r"(?<![\w/\\.-])[A-Za-z]{2,}(?![\w/\\.=-])")
+
+# A shell prompt or a leading path opens a command, not a sentence.
+SYNTAX_LEAD = re.compile(r"^(?:[$>#%]\s|\.{0,2}/|~/)")
+COMMAND_FLAG = re.compile(r"(?:^|\s)-{1,2}[A-Za-z]")
+
+
+def _is_prose(text):
+    """True when a tagged remainder reads as prose, not as command syntax.
+
+    `Usage:` and `@example` are usually followed by a command line, and the skill
+    puts command syntax out of scope. Counting it as prose pads the word count
+    that every rate divides by: one real `ensure` finding in a 45-word shell
+    script scored 2.22 and failed, and adding nine words of `./script.sh <ID>`
+    diluted it to 1.85 and passed.
+    """
+    if SYNTAX_LEAD.match(text):
+        return False
+    words = PROSE_WORD.findall(text)
+    # A short tail carrying a flag is an invocation. A longer one is prose that
+    # happens to name a flag, which is worth checking, so the length guard keeps
+    # "run with --verbose to see more output" in scope.
+    if len(words) < 5 and COMMAND_FLAG.search(text):
+        return False
+    return len(words) >= 2
+
+
+def strip_directive(text):
+    """Return the prose in one comment line, or "" when the line holds none."""
+    if SUPPRESS.match(text) or URL_ONLY.match(text):
+        return ""
+    tag = DOC_TAG.match(text)
+    if not tag:
+        return text.strip()
+    rest = TAG_OPERAND.sub("", text[tag.end():]).strip()
+    return rest if _is_prose(rest) else ""
 
 
 def group_line_comments(segments):
@@ -717,8 +774,9 @@ def extract_comment_blocks(text, syntax):
                      for line, part in parts]
         else:
             parts = [(line, part.strip()) for line, part in parts]
-        parts = [(line, part) for line, part in parts
-                 if part and line not in ignored and not DIRECTIVE.match(part)]
+        parts = [(line, strip_directive(part)) for line, part in parts
+                 if line not in ignored]
+        parts = [(line, part) for line, part in parts if part]
         if not parts:
             continue
         joined = mask_inline(" ".join(part for _, part in parts)).strip()

--- a/prose_lint.py
+++ b/prose_lint.py
@@ -25,12 +25,15 @@ documents the JSON schema and every flag, with examples.
 """
 
 import argparse
+import ast
 import fnmatch
+import io
 import json
 import os
 import re
 import shlex
 import sys
+import tokenize
 
 # --------------------------------------------------------------------------- #
 # Rule data
@@ -476,6 +479,55 @@ def extract_comments(text, syntax):
     return out
 
 
+def extract_python(text):
+    """Return comment and docstring segments from Python source, exactly.
+
+    A triple-quoted string is a docstring only where the grammar says so: the
+    first statement of a module, class or function. Everywhere else it is data --
+    a SQL block, a PEM key, an f-string template -- and scoring it as prose both
+    invents findings and pads the word count that every rate is divided by.
+    Measured before this function existed: 132,910 reported comment words across
+    four Python repos against 106,479 real ones, and one file failing a commit
+    on the word "BEGIN" inside `b\"\"\"-----BEGIN PUBLIC KEY-----\"\"\"`.
+
+    `ast` supplies the docstrings and `tokenize` the comments, so neither is
+    guessed. Returns None when the source does not parse, which tells the caller
+    to fall back to the regex scanner rather than skip the file: a syntax error
+    is a reason to lint less precisely, not a reason to stop linting.
+    """
+    try:
+        tree = ast.parse(text)
+    except (SyntaxError, ValueError):
+        return None
+
+    out = []
+    scopes = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+    for node in ast.walk(tree):
+        if not isinstance(node, scopes):
+            continue
+        body = getattr(node, "body", None)
+        if not body or not isinstance(body[0], ast.Expr):
+            continue
+        value = body[0].value
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            out.append(Segment(body[0].lineno, value.value, "block"))
+
+    try:
+        for token in tokenize.generate_tokens(io.StringIO(text).readline):
+            if token[0] != tokenize.COMMENT:
+                continue
+            body = token[1].lstrip("#")
+            # A shebang is machine configuration, not prose.
+            if token[2][0] == 1 and body.startswith("!"):
+                continue
+            out.append(Segment(token[2][0], body, "line"))
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        pass
+
+    out.sort(key=lambda segment: segment.line)
+    return out
+
+
 BLOCK_ORNAMENT = re.compile(r"^\s*[*!/#=\-]+\s?")
 DIRECTIVE = re.compile(
     r"^\s*(?:@\w+|:\w+:|\w+:\/\/|(?:type|param|returns?|raises?|yields?|arg|args|"
@@ -649,7 +701,11 @@ def extract_document(text):
 
 def extract_comment_blocks(text, syntax):
     """Return paragraph blocks for a source file, from its comments only."""
-    raw_segments = extract_comments(text, syntax)
+    raw_segments = None
+    if syntax is PYTHON:
+        raw_segments = extract_python(text)
+    if raw_segments is None:
+        raw_segments = extract_comments(text, syntax)
     src = text.split("\n")
     _, ignored = structural_lines(src)
     units = []

--- a/prose_lint.py
+++ b/prose_lint.py
@@ -126,6 +126,12 @@ CLOSER = [
 PASSIVE_OK = {
     "based", "related", "unrelated", "required", "intended", "supposed",
     "limited", "interested", "aware", "expected", "involved", "located",
+    # Predicate adjectives. "is needed" carries no more of a hidden actor than
+    # the "is required" directly above it, and telling an author to name one
+    # produces a worse sentence than the original.
+    "needed", "unused", "unchanged", "unaffected", "expired", "enabled",
+    "disabled", "named", "authenticated", "unauthenticated", "outdated",
+    "automated",
 }
 
 BE = r"(?:am|is|are|was|were|be|been|being)"
@@ -140,6 +146,19 @@ ING_NOUN = {
     "logging", "monitoring", "backing", "wiring", "casing", "sampling",
 }
 
+# Participles that report a state rather than an action in progress. "Verify the
+# server is running" and "no other process is using port 8000" are the correct
+# sentences; "use a simple tense" turns them into something that means less.
+#
+# `being` is here for a second reason. "is being drained" matched this check for
+# "is being" and passive_voice for "being drained", so one passive cost two
+# violations. The passive is the finding worth keeping.
+STATE_ING = {
+    "being", "missing", "running", "working", "failing", "passing",
+    "succeeding", "using", "listening", "waiting", "pending", "starting",
+    "stopping", "expecting",
+}
+
 # Contractions of "to be" or "to have" that end in 's. The possessive check has
 # to let these through, otherwise the most common contraction of all is invisible.
 S_CONTRACTIONS = {
@@ -151,12 +170,37 @@ PP_IRREG = (
     r"(?:done|made|sent|read|built|kept|held|set|put|run|written|shown|given"
     r"|taken|found|got|gotten|seen|known|thrown|drawn|left|lost|meant|sold)"
 )
+# `perform` and `conduct` are only nominalisations when they carry a nominalised
+# object: "performs an analysis of" hides "analyses". Bare "perform PKCE" is the
+# verb doing its job, and RFC 7636's own wording, so the determiner is required.
 NOMINALIZATION = re.compile(
-    r"\b(?:perform(?:s|ed)?|conduct(?:s|ed)?|carry out|carries out"
-    r"|make use of|makes use of|take (?:a look|action))\b",
+    r"\b(?:perform(?:s|ed)?|conduct(?:s|ed)?)\s+(?:an?|the)\s+\w+"
+    r"|\b(?:carry out|carries out|make use of|makes use of"
+    r"|take (?:a look|action))\b",
     re.I,
 )
 NOMINAL_OF = re.compile(r"\b(\w{4,}(?:tion|ment|ance|ence))\s+of\b", re.I)
+
+# Concrete nouns that merely end in a nominalising suffix. "The location of the
+# bucket" hides no verb: there is nothing to rewrite, and no shorter way to say
+# it. Without this list the suffix rule was wrong far more often than right --
+# 69 of 108 findings across 17 repositories were ordinary noun phrases.
+#
+# A word belongs here when the noun is the thing itself. Keep "detection",
+# "verification" and "deprecation" out of it: each really does bury a verb.
+NOMINAL_OK = {
+    "description", "location", "combination", "instance", "evidence",
+    "definition", "occurrence", "separation", "convenience", "reference",
+    "sequence", "difference", "presence", "absence", "audience", "experience",
+    "balance", "distance", "maintenance", "importance", "performance",
+    "appearance", "environment", "document", "argument", "element",
+    "component", "statement", "requirement", "increment", "segment", "moment",
+    "amount", "department", "permission", "extension", "dimension",
+    "condition", "position", "version", "section", "portion", "fraction",
+    "function", "connection", "collection", "option", "duration",
+    "information", "organization", "population", "proportion", "attention",
+    "relation", "percentage", "advancement",
+}
 
 FIX_HINT = {
     "long_sentence": "split into one idea per sentence",
@@ -833,6 +877,28 @@ SENT_SPLIT = re.compile(r"(?<=[.!?])" + _NOT_ABBREV + r"\s+(?=" + _SENT_LEAD + r
 WORD = re.compile(r"[A-Za-z0-9][A-Za-z0-9'\-/]*")
 
 
+# "TL;DR" is one token, not two clauses.
+SEMICOLON = re.compile(r"(?<!\bTL);")
+
+# Unit kinds that hold a fragment rather than a sentence. Sentence-level rules do
+# not apply to them, because the edit each rule asks for is not available.
+FRAGMENT_KINDS = ("heading", "table")
+
+
+def is_fragment(unit):
+    """True when a unit holds a fragment, so sentence-level rules do not apply.
+
+    A list item is prose when it is punctuated as prose. An unpunctuated one is a
+    label: `- Read-only: kubectl get; helm list` names two commands, and no
+    rewrite into two sentences exists.
+    """
+    if unit.kind in FRAGMENT_KINDS:
+        return True
+    if unit.kind == "list":
+        return not unit.text.rstrip().endswith((".", "!", "?"))
+    return False
+
+
 def sentences(text):
     return [p.strip() for p in SENT_SPLIT.split(text) if p.strip()]
 
@@ -907,8 +973,15 @@ def run_checks(blocks, cfg):
                             "%d words (max %d)" % (length, cfg["max_sentence_words"]),
                             sentence)
 
-            for match in re.finditer(r";", text):
-                add(unit, match.start(), "semicolon", "semicolon", text)
+            # A semicolon rule says "write two sentences", which is only an edit
+            # an author can make in prose. A table cell has no room for two
+            # sentences, a heading is a fragment, and a list item without
+            # terminal punctuation is a label joining items rather than clauses:
+            # "Read-only: kubectl get/describe; helm list/status". Measured over
+            # 17 repositories, 57% of semicolon findings sat in one of these.
+            if not is_fragment(unit):
+                for match in re.finditer(SEMICOLON, text):
+                    add(unit, match.start(), "semicolon", "semicolon", text)
 
             for match in re.finditer(r"\b\w+['’](?:t|re|ve|ll|d|s|m)\b", text):
                 word = match.group(0)
@@ -923,13 +996,16 @@ def run_checks(blocks, cfg):
                 add(unit, match.start(), "passive_voice", match.group(0), text)
 
             for match in re.finditer(r"\b%s\s+(\w+ing)\b" % BE, text, re.I):
-                if match.group(1).lower() in ING_NOUN:
-                    continue                            # a noun, not a verb
+                word = match.group(1).lower()
+                if word in ING_NOUN or word in STATE_ING:
+                    continue              # a noun or a state, not an action
                 add(unit, match.start(), "ing_main_verb", match.group(0), text)
 
             for match in NOMINALIZATION.finditer(text):
                 add(unit, match.start(), "nominalization", match.group(0), text)
             for match in NOMINAL_OF.finditer(text):
+                if match.group(1).lower() in NOMINAL_OK:
+                    continue                    # a thing, not a buried verb
                 add(unit, match.start(), "nominalization",
                     "%s of" % match.group(1), text)
 

--- a/prose_lint.py
+++ b/prose_lint.py
@@ -814,6 +814,21 @@ def run_checks(blocks, cfg):
 # --------------------------------------------------------------------------- #
 
 
+def _number(cast, value, what):
+    """Cast a configured number, reporting a bad one as a configuration error.
+
+    Without this the cast raised ValueError straight out of build_config, which
+    main() does not catch, so a typo exited 1 with a traceback. Exit 1 is the
+    documented code for prose over budget, so a misconfigured hook read as
+    failing prose.
+    """
+    try:
+        return cast(value)
+    except (TypeError, ValueError):
+        expected = "an integer" if cast is int else "a number"
+        raise ConfigError("%s expects %s, got %r" % (what, expected, value))
+
+
 def build_config(args):
     """Merge profile defaults, JSON config and CLI overrides, in that order."""
     raw = {}
@@ -864,9 +879,11 @@ def build_config(args):
         elif spec.get("enabled") is False:
             cfg["enabled"].discard(name)
         if "weight" in spec:
-            cfg["weights"][name] = float(spec["weight"])
+            cfg["weights"][name] = _number(
+                float, spec["weight"], "weight for check %r" % name)
         if "max" in spec:
-            cfg["max"][name] = None if spec["max"] is None else int(spec["max"])
+            cfg["max"][name] = (None if spec["max"] is None else
+                                _number(int, spec["max"], "max for check %r" % name))
 
     # CLI overrides win over the JSON config.
     if args.threshold is not None:
@@ -892,12 +909,12 @@ def build_config(args):
         name, _, value = item.partition("=")
         if name not in ALL_CHECKS or not value:
             raise ConfigError("--weight expects CHECK=NUMBER, got %r" % item)
-        cfg["weights"][name] = float(value)
+        cfg["weights"][name] = _number(float, value, "--weight %s" % name)
     for item in args.max or []:
         name, _, value = item.partition("=")
         if name not in ALL_CHECKS or not value:
             raise ConfigError("--max expects CHECK=INTEGER, got %r" % item)
-        cfg["max"][name] = int(value)
+        cfg["max"][name] = _number(int, value, "--max %s" % name)
 
     # Project vocabulary.
     banned = dict(BANNED)

--- a/prose_lint.py
+++ b/prose_lint.py
@@ -10,9 +10,11 @@ English: word choice, sentence length, voice, hedging, marketing language and
 paragraph size. Judgment rules (is the noun the right noun, is the claim true)
 need a human and are not checked here.
 
-Two independent enforcement mechanisms, both configurable per check:
-  threshold - weighted violations per 100 words, for prose of any length
-  max       - absolute count cap, for zero-tolerance checks
+Three independent enforcement mechanisms:
+  threshold       - weighted violations per 100 words, at or above min_words
+  short_allowance - absolute violation count below min_words, where a rate says
+                    more about length than about quality
+  max             - absolute count cap per check, for zero-tolerance checks
 
 Every check can be enabled, disabled or re-weighted, so a project can tune the
 rule set without editing this file. Configuration comes from a profile, then a
@@ -43,6 +45,7 @@ BANNED = {
     "ensure": "make sure", "ensures": "makes sure", "ensuring": "making sure",
     "commence": "start", "commences": "starts", "commenced": "started",
     "initiate": "start", "initiates": "starts", "initiated": "started",
+    "begin": "start", "begins": "starts", "began": "started",
     "terminate": "stop", "terminates": "stops", "terminated": "stopped",
     "obtain": "get", "obtains": "gets", "obtained": "got",
     "acquire": "get", "acquires": "gets", "acquired": "got",
@@ -79,7 +82,7 @@ MARKETING = [
     "effortlessly", "world-class", "next-generation", "revolutionary", "blazing",
     "lightning-fast", "elegant", "delightful", "turnkey", "best-in-class",
     "state-of-the-art", "game-changing", "first-class", "battle-tested",
-    "enterprise-grade", "supercharge", "unleash", "empower", "empowers",
+    "enterprise-grade", "supercharge", "unlock", "unleash", "empower", "empowers",
     "rich set of", "sensible defaults", "minimal friction", "out of the box",
 ]
 
@@ -92,12 +95,13 @@ PHRASAL = {
     "roll out": "deploy", "rolls out": "deploys", "rolled out": "deployed",
     "tear down": "remove", "ramp up": "increase",
     "circle back": "revisit", "drill down": "examine",
+    "stand up": "create", "stood up": "created",
 }
 
 HEDGE = [
     "it is important to note", "it should be noted", "it is worth noting",
-    "please note that", "as mentioned above", "as noted above", "as we all know",
-    "needless to say", "it goes without saying", "generally speaking",
+    "please note that", "as mentioned", "as noted above", "as we all know",
+    "needless to say", "it goes without saying", "arguably", "generally speaking",
 ]
 
 INTENSIFIER = [
@@ -106,19 +110,40 @@ INTENSIFIER = [
 ]
 
 CLOSER = [
-    "in summary", "in conclusion", "to summarize", "all in all",
-    "at the end of the day", "provides a foundation", "sets the stage",
-    "paves the way", "going forward", "the possibilities are endless",
+    "in summary", "in conclusion", "to summarize", "overall,", "all in all",
+    "at the end of the day", "provides a foundation", "provides a solid foundation",
+    "sets the stage", "paves the way", "going forward", "in today's",
+    "the possibilities are endless",
 ]
 
 # Participles that read as adjectives, not as a passive with a hidden actor.
+# Kept identical to the skill's list on purpose. "is deprecated", "is documented"
+# and "is supported" were exempt here and are not exempt in the skill: each has a
+# hidden actor worth naming, so the skill's stricter reading wins.
 PASSIVE_OK = {
     "based", "related", "unrelated", "required", "intended", "supposed",
     "limited", "interested", "aware", "expected", "involved", "located",
-    "deprecated", "documented", "supported", "named", "called",
 }
 
 BE = r"(?:am|is|are|was|were|be|been|being)"
+
+# Nouns and prepositions that end in -ing. "The result is something" is not a
+# progressive verb, so the ing_main_verb check has to skip these.
+ING_NOUN = {
+    "anything", "something", "nothing", "everything", "thing", "things",
+    "during", "morning", "evening", "spring", "string", "strings", "king",
+    "ring", "ceiling", "sibling", "siblings", "offering", "offerings",
+    "warning", "warnings", "meaning", "engineering", "onboarding", "tooling",
+    "logging", "monitoring", "backing", "wiring", "casing", "sampling",
+}
+
+# Contractions of "to be" or "to have" that end in 's. The possessive check has
+# to let these through, otherwise the most common contraction of all is invisible.
+S_CONTRACTIONS = {
+    "it's", "that's", "there's", "let's", "what's", "here's", "he's", "she's",
+    "who's", "where's", "how's", "one's", "everything's", "nothing's",
+}
+
 PP_IRREG = (
     r"(?:done|made|sent|read|built|kept|held|set|put|run|written|shown|given"
     r"|taken|found|got|gotten|seen|known|thrown|drawn|left|lost|meant|sold)"
@@ -156,31 +181,76 @@ ALL_CHECKS = [
     "banned_word", "marketing_adjective", "hedge", "intensifier", "empty_closer",
 ]
 
-DEFAULT_WEIGHTS = {
-    "long_sentence": 1.0,
-    "long_paragraph": 1.0,
-    "semicolon": 1.0,
-    "contraction": 0.5,
-    "passive_voice": 1.0,
-    "ing_main_verb": 0.5,
-    "nominalization": 1.0,
-    "phrasal_verb": 0.5,
-    "banned_word": 1.0,
-    "marketing_adjective": 1.5,
-    "hedge": 1.5,
-    "intensifier": 0.5,
-    "empty_closer": 1.5,
-}
+# Every check weighs 1.0, so the score is a plain violation count per 100 words
+# and matches the technical-writing skill's linter on the same text. Two tools
+# reporting different numbers for one document is its own problem: a reviewer
+# cannot tell whether prose improved or the scorer changed its mind.
+#
+# The weighting machinery stays, because --weight and the JSON config are how a
+# project tunes this without editing the file. Only the defaults are uniform. Set
+# a weight below 1.0 to make a check advisory, above 1.0 to make one count double.
+DEFAULT_WEIGHTS = dict((name, 1.0) for name in ALL_CHECKS)
 
 # Checks that are almost always right, even on a terse code comment.
 HIGH_SIGNAL = ["banned_word", "marketing_adjective", "hedge", "empty_closer"]
 
+# Everything except intensifiers. The skill checks intensifiers in strict mode
+# only, because "significantly" and "highly" carry real meaning in a design doc
+# and the relaxed word list is what lets standard prose keep its range.
+DOC_CHECKS = [name for name in ALL_CHECKS if name != "intensifier"]
+
+# --------------------------------------------------------------------------- #
+# Why `short_allowance` exists, and why it is 1
+#
+# The document profiles mirror the technical-writing skill's linter, which is the
+# source of truth for these numbers: a 100-word floor, allowance 1 at the standard
+# threshold and 0 in strict mode, and a count rather than a rate below the floor.
+#
+# The rate is violations / words * 100 against a threshold of 2.0, so prose gets
+# 50 words of runway per allowed violation. Below roughly 100 words that rate is a
+# near-binary the threshold slices through arbitrarily. Measured on a 43-file,
+# 17k-word corpus, with the rate alone:
+#
+#     words  violations  score  verdict
+#        36           1   2.78  FAIL
+#        45           1   2.22  FAIL
+#        52           1   1.92  PASS
+#        50           2   4.00  FAIL
+#
+# Identical defect counts, opposite verdicts, seven words apart. Of 13 documents
+# under 100 words, 10 carried zero violations, so short prose can reach zero and
+# the rate was not doing useful work at that length.
+#
+# The rate also does not compare across lengths. A score of 2.78 is one defect in
+# 36 words and about 55 defects in 2000. Ranking by score put a 50-word index page
+# at 4.00 above a 1937-word architecture document at 3.56, so the metric
+# misdirected an audit rather than guiding it.
+#
+# Allowance of 1 was chosen over the alternatives. Zero is stricter than the old
+# behavior, flips the 52-word file from pass to fail, and lets a single "don't"
+# gate a commit. Two means nothing under 100 words could realistically fail, so
+# the check stops catching anything. One removes the cliff, still fails prose with
+# two real defects, and states in one sentence with no arithmetic: short prose may
+# carry at most one violation. The `strict` profile takes 0 deliberately, because
+# error messages and commit bodies are short by nature and have no budget
+# argument.
+#
+# REJECTED, deliberately: a denominator floor, per_100w = violations * 100 /
+# max(words, 100). It is one line and yields similar verdicts, but it reports a
+# rate that was never measured -- a reader seeing 1.0 on a 23-word document would
+# infer 0.23 violations. The rule here changes the verdict and keeps the reported
+# number true, which is why short prose prints a count and no rate at all.
+# Collapsing `is_short` and `short_allowance` back into a denominator fudge is a
+# regression, not a simplification.
+# --------------------------------------------------------------------------- #
+
 PROFILES = {
     # Whole-file documentation. Every check, rate-based enforcement.
     "docs": {
-        "enabled": list(ALL_CHECKS),
+        "enabled": list(DOC_CHECKS),
         "threshold": 2.0,
-        "min_words": 50,
+        "min_words": 100,
+        "short_allowance": 1,
         "max_sentence_words": 25,
         "max_paragraph_sentences": 6,
         "max": {},
@@ -189,7 +259,8 @@ PROFILES = {
     "strict": {
         "enabled": list(ALL_CHECKS),
         "threshold": 0.5,
-        "min_words": 30,
+        "min_words": 100,
+        "short_allowance": 0,
         "max_sentence_words": 20,
         "max_paragraph_sentences": 6,
         "max": {"hedge": 0, "marketing_adjective": 0},
@@ -203,10 +274,22 @@ PROFILES = {
     # slop ("utilize") to words that read as ordinary English in a docstring
     # ("ensure"). An absolute cap there fails normal code on its first commit,
     # which is how a hook gets switched off.
+    #
+    # This profile deliberately does not follow the skill. The skill governs whole
+    # documents, and its 100-word floor is calibrated for one. Comment prose is a
+    # different unit: a 40-word floor keeps the rate meaningful for a file with a
+    # handful of docstrings, where a 100-word floor would switch the rate off for
+    # most files and leave only the caps.
+    #
+    # `short_allowance` is null here on purpose. A count rule on a short comment
+    # would put banned_word back under an absolute cap by the back door, which is
+    # the outcome the rate-based split above exists to avoid. The zero caps
+    # already give the high-signal checks zero tolerance at any length.
     "comments": {
         "enabled": list(HIGH_SIGNAL),
         "threshold": 2.0,
         "min_words": 40,
+        "short_allowance": None,
         "max_sentence_words": 30,
         "max_paragraph_sentences": 0,
         "max": {"marketing_adjective": 0, "hedge": 0, "empty_closer": 0},
@@ -449,6 +532,8 @@ IGNORE_END = re.compile(r"(?:<!--|#|//)\s*prose-lint:\s*ignore-end\s*(?:-->)?")
 def mask_inline(text):
     """Remove spans that are code or addresses, not prose."""
     text = re.sub(r"``[^`]*``|`[^`]*`", " CODE ", text)
+    text = re.sub(r"&(?:[a-zA-Z][a-zA-Z0-9]{1,9}|#\d{1,5}|#x[0-9a-fA-F]{1,5});",
+                  " ", text)                            # &nbsp; is not a semicolon
     text = re.sub(r"!\[[^\]]*\]\([^)]*\)", " IMAGE ", text)
     text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
     text = re.sub(r"\[\[[^\]|]*\|([^\]]*)\]\]", r"\1", text)
@@ -589,7 +674,20 @@ def extract_comment_blocks(text, syntax):
 # Checks
 # --------------------------------------------------------------------------- #
 
-SENT_SPLIT = re.compile(r"(?<=[.!?])\s+(?=[A-Z0-9\"'(])")
+# Do not split after an abbreviation. Each lookbehind must be fixed width, so
+# they are listed separately rather than as one alternation. The lone-capital
+# rule needs the leading space: without it, a sentence ending in an acronym
+# ("... aligned with MRC.") would never split.
+_NOT_ABBREV = (
+    r"(?<![Ee]\.[Gg]\.)(?<![Ii]\.[Ee]\.)(?<!\bvs\.)(?<!\betc\.)(?<!\bcf\.)"
+    r"(?<!\bal\.)(?<!\bInc\.)(?<!\bLtd\.)(?<!\bNo\.)(?<!\bFig\.)"
+    r"(?<!\bapprox\.)(?<!\bDr\.)(?<!\bMr\.)(?<!\bMs\.)(?<!\s[A-Z]\.)"
+)
+# A sentence may open with markdown emphasis or a link bracket. Without these in
+# the lookahead, "Foo. **Bar** does X." reads as one sentence and its length is
+# reported as the sum of both.
+_SENT_LEAD = r"""[*_`\[]*[A-Z0-9"'(]"""
+SENT_SPLIT = re.compile(r"(?<=[.!?])" + _NOT_ABBREV + r"\s+(?=" + _SENT_LEAD + r")")
 WORD = re.compile(r"[A-Za-z0-9][A-Za-z0-9'\-/]*")
 
 
@@ -658,8 +756,9 @@ def run_checks(blocks, cfg):
 
             for match in re.finditer(r"\b\w+['’](?:t|re|ve|ll|d|s|m)\b", text):
                 word = match.group(0)
-                if word.lower().endswith(("'s", "’s")):
-                    continue
+                norm = word.lower().replace("’", "'")
+                if norm.endswith("'s") and norm not in S_CONTRACTIONS:
+                    continue                    # possessive, not a contraction
                 add(line, "contraction", word, text)
 
             for match in re.finditer(r"\b(%s)\s+(\w+ed|%s)\b" % (BE, PP_IRREG), text, re.I):
@@ -668,6 +767,8 @@ def run_checks(blocks, cfg):
                 add(line, "passive_voice", match.group(0), text)
 
             for match in re.finditer(r"\b%s\s+(\w+ing)\b" % BE, text, re.I):
+                if match.group(1).lower() in ING_NOUN:
+                    continue                            # a noun, not a verb
                 add(line, "ing_main_verb", match.group(0), text)
 
             for match in NOMINALIZATION.finditer(text):
@@ -734,6 +835,7 @@ def build_config(args):
         "profile": profile_name,
         "threshold": profile["threshold"],
         "min_words": profile["min_words"],
+        "short_allowance": profile["short_allowance"],
         "max_sentence_words": profile["max_sentence_words"],
         "max_paragraph_sentences": profile["max_paragraph_sentences"],
         "weights": dict(DEFAULT_WEIGHTS),
@@ -741,8 +843,8 @@ def build_config(args):
         "enabled": set(profile["enabled"]),
     }
 
-    for key in ("threshold", "min_words", "max_sentence_words",
-                "max_paragraph_sentences"):
+    for key in ("threshold", "min_words", "short_allowance",
+                "max_sentence_words", "max_paragraph_sentences"):
         if key in raw:
             cfg[key] = raw[key]
 
@@ -766,6 +868,8 @@ def build_config(args):
         cfg["threshold"] = args.threshold
     if args.min_words is not None:
         cfg["min_words"] = args.min_words
+    if args.short_allowance is not None:
+        cfg["short_allowance"] = args.short_allowance
     if args.max_sentence_words is not None:
         cfg["max_sentence_words"] = args.max_sentence_words
     if args.max_paragraph_sentences is not None:
@@ -831,6 +935,13 @@ def evaluate(path, text, cfg, kind, syntax):
     findings = run_checks(blocks, cfg)
     counts, weighted, rate = score(findings, words, cfg)
 
+    # Headings and table cells are fragments, so they are excluded here for the
+    # same reason the long_sentence check excludes them.
+    longest = max((word_count(sentence)
+                   for block in blocks for unit in block
+                   if unit.kind not in ("heading", "table")
+                   for sentence in sentences(unit.text)), default=0)
+
     reasons = []
     for name, cap in sorted(cfg["max"].items()):
         if cap is None or name not in cfg["enabled"]:
@@ -839,12 +950,19 @@ def evaluate(path, text, cfg, kind, syntax):
         if found > cap:
             reasons.append("%s: %d found, max %d" % (name, found, cap))
 
-    over_threshold = rate > cfg["threshold"]
-    if words < cfg["min_words"]:
-        # Rate-based scoring is noise on very short prose: a single violation in
-        # a 12-word comment reads as 8 per 100 words. Absolute caps still apply.
-        over_threshold = False
-    if over_threshold:
+    # Below min_words a rate is meaningless: at threshold 2.0 prose needs 50 words
+    # of runway per allowed violation, so one defect passes at 52 words and fails
+    # at 45. Short prose is judged on the absolute count instead, and its rate is
+    # not reported as a verdict at all. A null allowance disables the count rule
+    # and leaves only the per-check caps, which is what the comments profile wants.
+    short = words < cfg["min_words"]
+    allowance = cfg["short_allowance"]
+    found = len(findings)
+    if short:
+        if allowance is not None and found > allowance:
+            reasons.append("%d violation%s in %d words (short-doc rule: max %d)"
+                           % (found, "" if found == 1 else "s", words, allowance))
+    elif rate > cfg["threshold"]:
         reasons.append("score %.2f per 100 words, max %.2f" % (rate, cfg["threshold"]))
 
     return {
@@ -855,9 +973,51 @@ def evaluate(path, text, cfg, kind, syntax):
         "counts": counts,
         "weighted": weighted,
         "rate": rate,
+        "longest_sentence": longest,
+        "is_short": short,
+        "short_allowance": allowance,
         "reasons": reasons,
         "passed": not reasons,
     }
+
+
+def totals(results):
+    """Corpus rollup across every file linted in one run.
+
+    The corpus rate is recomputed from the pooled weight and word count, not
+    averaged from the per-file rates, so a long file counts for more than a
+    three-line one.
+    """
+    words = sum(result["words"] for result in results)
+    weighted = sum(result["weighted"] for result in results)
+    counts = {}
+    for result in results:
+        for name, found in result["counts"].items():
+            counts[name] = counts.get(name, 0) + found
+    return {
+        "files": len(results),
+        "failing": sum(1 for result in results if not result["passed"]),
+        "short_files": sum(1 for result in results if result["is_short"]),
+        "words": words,
+        "findings": sum(counts.values()),
+        "weighted": round(weighted, 2),
+        "rate": round(weighted * 100.0 / words, 2) if words else 0.0,
+        "longest_sentence": max((result["longest_sentence"]
+                                 for result in results), default=0),
+        "counts": dict(sorted(counts.items(), key=lambda kv: -kv[1])),
+    }
+
+
+def print_totals(total, cfg):
+    """Human-readable rollup. Goes to stderr, because stdout carries --json."""
+    short = ", %d short" % total["short_files"] if total["short_files"] else ""
+    err("prose-lint TOTAL  %d files, %d words, %d failing%s"
+        % (total["files"], total["words"], total["failing"], short))
+    err("  score %.2f per 100 words (max %.2f)  longest sentence %d words"
+        % (total["rate"], cfg["threshold"], total["longest_sentence"]))
+    for name, found in total["counts"].items():
+        share = found * 100.0 / max(total["findings"], 1)
+        err("  %-22s %5d  %5.1f%%" % (name, found, share))
 
 
 def err(message):
@@ -907,7 +1067,12 @@ def main():
     parser.add_argument("--threshold", type=float, default=None,
                         help="maximum weighted violations per 100 words")
     parser.add_argument("--min-words", type=int, default=None, dest="min_words",
-                        help="below this word count, only absolute caps apply")
+                        help="below this word count, judge on the absolute "
+                             "violation count instead of the rate")
+    parser.add_argument("--short-allowance", type=int, default=None,
+                        dest="short_allowance", metavar="N",
+                        help="violations tolerated below --min-words "
+                             "(default: 1 docs, 0 strict, none for comments)")
     parser.add_argument("--max-sentence-words", type=int, default=None,
                         dest="max_sentence_words")
     parser.add_argument("--max-paragraph-sentences", type=int, default=None,
@@ -928,6 +1093,8 @@ def main():
                         help="omit the quoted excerpt under each finding")
     parser.add_argument("--json", action="store_true", dest="as_json",
                         help="emit machine-readable results")
+    parser.add_argument("--total", action="store_true",
+                        help="add a corpus rollup: score, failing count, check shares")
     parser.add_argument("--list-checks", action="store_true",
                         help="print the checks with default weights and exit")
 
@@ -966,17 +1133,26 @@ def main():
         results.append(evaluate(path, text, cfg, kind, syntax))
 
     if args.as_json:
-        print(json.dumps([{
+        payload = [{
             "path": r["path"], "kind": r["kind"], "words": r["words"],
             "weighted": r["weighted"], "rate": r["rate"], "passed": r["passed"],
+            "longest_sentence": r["longest_sentence"],
+            "is_short": r["is_short"], "short_allowance": r["short_allowance"],
             "counts": r["counts"], "reasons": r["reasons"],
             "findings": [{"line": f.line, "check": f.check, "detail": f.detail,
                           "excerpt": f.excerpt} for f in r["findings"]],
-        } for r in results], indent=2))
+        } for r in results]
+        if args.total:
+            print(json.dumps({"files": payload, "total": totals(results)},
+                             indent=2))
+        else:
+            print(json.dumps(payload, indent=2))
     else:
         for result in results:
             if not result["passed"] or (args.warn_only and result["findings"]):
                 report(result, args.quiet)
+        if args.total:
+            print_totals(totals(results), cfg)
 
     failed = [r for r in results if not r["passed"]]
     if failed and args.warn_only:

--- a/tests/test_prose_lint.py
+++ b/tests/test_prose_lint.py
@@ -1,0 +1,743 @@
+#!/usr/bin/env python3
+"""Baseline tests for prose_lint.py.
+
+Run with the standard library alone, from the repository root:
+
+    python3 -m unittest discover -s tests -v
+
+The suite is a baseline in the literal sense: it pins current behaviour so that a
+later rule change shows up as an intentional diff rather than as silent drift.
+prose_lint.py is 1000+ lines of regex-dense heuristics whose output every repo in
+the organisation is scored against, so an unreviewed shift in any word list moves
+every score at once.
+
+Every fixture here is synthetic and generic. Nothing depends on a real repository,
+a real document or a company-specific term, because a test that reads a file
+outside this repository fails for reasons that have nothing to do with the linter.
+
+Layout, in the order a reader should meet it:
+
+    ExitCodeTests            the 0/1/2 contract the hook and README promise
+    ThresholdTests           the rate, the short-document rule and the caps
+    ConfigTests              profile -> JSON -> CLI layering, vocabulary edits
+    SuppressionTests         ignore markers, fenced code, frontmatter
+    DocumentExtractionTests  which markdown is prose and which is structure
+    CommentExtractionTests   the per-language comment and docstring tables
+    PythonExtractionTests    docstrings via ast, comments via tokenize
+    DirectiveTests           tool directives versus documentation tags
+    LineAttributionTests     a finding names the line holding its text
+    PerformanceTests         a guard against the O(n^2) excerpt regression
+    HostileInputTests        empty, CRLF, unterminated, unreadable
+    GoldenTests              a pinned document, checked whole
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, ROOT)
+
+import prose_lint  # noqa: E402
+
+LINT = os.path.join(ROOT, "prose_lint.py")
+
+# Clean filler used to push a fixture over the 100-word floor without adding a
+# violation. Kept deliberately dull: any word here that later joins a rule list
+# would turn every threshold test into a false failure.
+FILLER = (
+    "The parser reads one record at a time. The writer stores each record. "
+    "The reader returns the next record. The queue holds the pending records. "
+    "The worker takes a record from the queue. The log keeps one line per record. "
+    "The report counts the records. The cache holds the recent records. "
+    "The index maps a key to a record. The server sends the record to the client. "
+)
+
+
+def filler_words(count):
+    """Return at least `count` words of violation-free prose, in paragraphs.
+
+    The paragraph breaks are not decoration. Six sentences in one block trips
+    long_paragraph, so filler written as a single block would fail every
+    threshold fixture for a reason the fixture was not testing.
+    """
+    pool = [s.strip() for s in (FILLER * (count // 40 + 2)).split(".") if s.strip()]
+    paragraphs, current, total = [], [], 0
+    for sentence in pool:
+        current.append(sentence + ".")
+        total += len(sentence.split())
+        if len(current) == 3:
+            paragraphs.append(" ".join(current))
+            current = []
+        if total >= count and not current:
+            break
+    if current:
+        paragraphs.append(" ".join(current))
+    return "\n\n".join(paragraphs)
+
+
+class Harness(unittest.TestCase):
+    """Shared helpers. Every test drives the real command line."""
+
+    def write(self, name, text):
+        """Write a fixture into a per-test temporary directory."""
+        if not hasattr(self, "_dir"):
+            self._dir = tempfile.mkdtemp(prefix="prose-lint-test-")
+            self.addCleanup(self._cleanup)
+        path = os.path.join(self._dir, name)
+        parent = os.path.dirname(path)
+        if parent and not os.path.isdir(parent):
+            os.makedirs(parent)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        return path
+
+    def write_bytes(self, name, payload):
+        """Write a fixture that is deliberately not valid UTF-8 text."""
+        path = self.write(name, "")
+        with open(path, "wb") as handle:
+            handle.write(payload)
+        return path
+
+    def _cleanup(self):
+        for root, dirs, files in os.walk(self._dir, topdown=False):
+            for name in files:
+                os.unlink(os.path.join(root, name))
+            for name in dirs:
+                os.rmdir(os.path.join(root, name))
+        os.rmdir(self._dir)
+
+    def run_lint(self, *args):
+        """Run the hook as a subprocess. Returns (exit code, stdout, stderr)."""
+        proc = subprocess.run([sys.executable, LINT] + list(args),
+                              capture_output=True, text=True)
+        return proc.returncode, proc.stdout, proc.stderr
+
+    def evaluate(self, *args):
+        """Run the hook with --json and return the single file result."""
+        code, out, err = self.run_lint("--json", *args)
+        self.assertNotEqual(code, 2, "configuration error: %s" % err)
+        payload = json.loads(out)
+        self.assertEqual(len(payload), 1, "expected exactly one result")
+        return payload[0]
+
+    def checks(self, *args):
+        """Return {check name: count} for one file."""
+        return self.evaluate(*args)["counts"]
+
+    def lines_for(self, check, *args):
+        """Return the reported line numbers for one check, in order."""
+        return [f["line"] for f in self.evaluate(*args)["findings"]
+                if f["check"] == check]
+
+
+class ExitCodeTests(Harness):
+    """0 means clean, 1 means over budget, 2 means the run was misconfigured.
+
+    The distinction matters more than it looks: a caller that cannot tell a
+    misconfigured hook from failing prose reports a typo in its own YAML as an
+    author's writing problem.
+    """
+
+    def test_clean_document_exits_zero(self):
+        path = self.write("clean.md", "# Title\n\n%s\n" % filler_words(120))
+        self.assertEqual(self.run_lint(path)[0], 0)
+
+    def test_document_over_budget_exits_one(self):
+        text = "# Title\n\nWe utilize the seamless robust approach.\n\n%s\n" % filler_words(40)
+        path = self.write("bad.md", text)
+        self.assertEqual(self.run_lint(path)[0], 1)
+
+    def test_warn_only_exits_zero_while_still_reporting(self):
+        text = "# Title\n\nWe utilize the seamless robust approach.\n"
+        path = self.write("warn.md", text)
+        code, _, err = self.run_lint("--warn-only", path)
+        self.assertEqual(code, 0)
+        self.assertIn("utilize", err)
+        self.assertIn("not blocking", err)
+
+    def test_unknown_profile_exits_two(self):
+        path = self.write("doc.md", "# Title\n")
+        self.assertEqual(self.run_lint("--profile", "nope", path)[0], 2)
+
+    def test_unreadable_paths_exit_two(self):
+        missing = os.path.join(tempfile.gettempdir(), "prose-lint-absent.md")
+        self.assertEqual(self.run_lint(missing)[0], 2)
+        # A directory only reaches the reader if its name classifies as prose.
+        self.write("doc.md", "# Title\n")
+        as_dir = os.path.join(self._dir, "folder.md")
+        os.makedirs(as_dir)
+        self.assertEqual(self.run_lint(as_dir)[0], 2)
+
+    def test_malformed_json_config_exits_two(self):
+        path = self.write("doc.md", "# Title\n")
+        self.assertEqual(self.run_lint("--config", "{not json", path)[0], 2)
+        self.assertEqual(self.run_lint("--config", "[1, 2]", path)[0], 2)
+
+    def test_unknown_check_name_exits_two(self):
+        path = self.write("doc.md", "# Title\n")
+        for flag in ("--enable", "--disable"):
+            self.assertEqual(self.run_lint(flag, "nosuchcheck", path)[0], 2)
+        self.assertEqual(self.run_lint("--weight", "nosuchcheck=2", path)[0], 2)
+
+    def test_non_numeric_config_values_exit_two(self):
+        """A bad number is a configuration error, not failing prose.
+
+        These four exited 1 with an uncaught ValueError traceback before the
+        conversions were routed through a configuration error.
+        """
+        path = self.write("doc.md", "# Title\n")
+        cases = [
+            ("--weight", "semicolon=bar"),
+            ("--max", "semicolon=1.5"),
+            ("--threshold", "nope"),
+            ("--min-words", "nope"),
+        ]
+        for flag, value in cases:
+            code, _, err = self.run_lint(flag, value, path)
+            self.assertEqual(code, 2, "%s %s should exit 2, got %d" % (flag, value, code))
+            self.assertNotIn("Traceback", err)
+        for blob in ('{"checks": {"semicolon": {"weight": "bar"}}}',
+                     '{"checks": {"semicolon": {"max": "bar"}}}'):
+            code, _, err = self.run_lint("--config", blob, path)
+            self.assertEqual(code, 2)
+            self.assertNotIn("Traceback", err)
+
+
+class ThresholdTests(Harness):
+    """The three enforcement mechanisms, and the handover between them."""
+
+    def test_rate_applies_at_or_above_the_word_floor(self):
+        """At or above the floor the verdict is a rate, and the rate is reported."""
+        text = "# Title\n\nWe utilize the approach.\n\n%s\n" % filler_words(110)
+        result = self.evaluate(self.write("rate.md", text))
+        self.assertFalse(result["is_short"])
+        self.assertGreater(result["rate"], 0.0)
+        self.assertTrue(result["passed"], "one violation in 110 words is under budget")
+
+    def test_long_document_fails_once_the_rate_passes_the_threshold(self):
+        slop = "We utilize and leverage and obtain and facilitate this. "
+        text = "# Title\n\n%s\n\n%s\n" % (slop, filler_words(110))
+        result = self.evaluate(self.write("overrate.md", text))
+        self.assertFalse(result["is_short"])
+        self.assertFalse(result["passed"])
+        self.assertIn("per 100 words", " ".join(result["reasons"]))
+
+    def test_short_document_is_judged_on_count_and_reports_no_rate(self):
+        """Below the floor a rate says more about length than about quality."""
+        path = self.write("short.md", "# Title\n\nWe utilize the approach.\n")
+        result = self.evaluate(path)
+        self.assertTrue(result["is_short"])
+        self.assertTrue(result["passed"], "one violation is within the allowance")
+        self.assertEqual(result["reasons"], [])
+
+    def test_short_document_fails_on_the_second_violation(self):
+        path = self.write("short2.md", "# Title\n\nWe utilize and leverage it.\n")
+        result = self.evaluate(path)
+        self.assertTrue(result["is_short"])
+        self.assertFalse(result["passed"])
+        self.assertIn("short-doc rule", " ".join(result["reasons"]))
+
+    def test_short_allowance_of_zero_fails_a_single_violation(self):
+        path = self.write("strict.md", "# Title\n\nWe utilize the approach.\n")
+        result = self.evaluate("--short-allowance", "0", path)
+        self.assertFalse(result["passed"])
+
+    def test_null_short_allowance_leaves_only_the_caps(self):
+        """The comments profile disables the count rule on purpose.
+
+        A count rule on a short comment would put every rate-based check back
+        under an absolute cap by the back door.
+        """
+        path = self.write("mod.py", '"""We utilize and leverage and obtain it."""\n')
+        result = self.evaluate("--profile", "comments", path)
+        self.assertTrue(result["is_short"])
+        self.assertIsNone(result["short_allowance"])
+        self.assertTrue(result["passed"])
+
+    def test_absolute_cap_fails_independently_of_the_rate(self):
+        text = '"""This is a seamless approach."""\n'
+        path = self.write("cap.py", text)
+        result = self.evaluate("--profile", "comments", path)
+        self.assertFalse(result["passed"])
+        self.assertIn("marketing_adjective", " ".join(result["reasons"]))
+
+    def test_sentence_and_paragraph_caps_are_configurable(self):
+        sentence = "The parser reads " + " ".join(["one"] * 30) + " record.\n"
+        path = self.write("sent.md", "# Title\n\n%s" % sentence)
+        self.assertEqual(self.checks(path).get("long_sentence", 0), 1)
+        self.assertEqual(
+            self.checks("--max-sentence-words", "60", path).get("long_sentence", 0), 0)
+
+    def test_paragraph_cap_counts_sentences_not_lines(self):
+        body = " ".join("The parser reads record %d." % n for n in range(8))
+        path = self.write("para.md", "# Title\n\n%s\n" % body)
+        self.assertEqual(self.checks(path).get("long_paragraph", 0), 1)
+        self.assertEqual(
+            self.checks("--max-paragraph-sentences", "20", path).get("long_paragraph", 0), 0)
+
+    def test_headings_and_table_cells_are_not_sentences(self):
+        """Both are fragments, so neither carries a sentence-length verdict."""
+        heading = "# " + " ".join(["word"] * 40) + "\n"
+        row = "| " + " ".join(["word"] * 40) + " |\n"
+        path = self.write("frag.md", heading + "\n" + row)
+        self.assertEqual(self.checks(path).get("long_sentence", 0), 0)
+
+
+class ConfigTests(Harness):
+    """Profile, then JSON, then command line, each overriding the last."""
+
+    def test_command_line_beats_json_config(self):
+        text = "# Title\n\nWe utilize the approach.\n\n%s\n" % filler_words(110)
+        path = self.write("doc.md", text)
+        self.assertTrue(self.evaluate("--config", '{"threshold": 9.0}', path)["passed"])
+        # The command line wins, so the generous JSON threshold does not apply.
+        self.assertFalse(self.evaluate("--config", '{"threshold": 9.0}',
+                                       "--threshold", "0.1", path)["passed"])
+
+    def test_json_config_beats_the_profile(self):
+        path = self.write("doc.md", "# Title\n")
+        result = self.evaluate("--config", '{"min_words": 1}', path)
+        self.assertFalse(result["is_short"])
+
+    def test_disable_wins_over_enable_for_the_same_check(self):
+        path = self.write("doc.md", "# Title\n\nIt is very fast.\n")
+        counts = self.checks("--enable", "intensifier", "--disable", "intensifier", path)
+        self.assertEqual(counts.get("intensifier", 0), 0)
+
+    def test_allow_removes_a_word_from_both_lists(self):
+        path = self.write("doc.md", "# Title\n\nWe utilize the seamless approach.\n")
+        counts = self.checks("--allow", "utilize", "--allow", "seamless", path)
+        self.assertEqual(counts.get("banned_word", 0), 0)
+        self.assertEqual(counts.get("marketing_adjective", 0), 0)
+
+    def test_project_vocabulary_can_be_extended(self):
+        path = self.write("doc.md", "# Title\n\nThe widget is frobnicated and zesty.\n")
+        blob = json.dumps({"extra_banned": {"frobnicated": "processed"},
+                           "extra_marketing": ["zesty"]})
+        counts = self.checks("--config", blob, path)
+        self.assertEqual(counts.get("banned_word", 0), 1)
+        self.assertEqual(counts.get("marketing_adjective", 0), 1)
+
+    def test_weight_scales_the_score_without_changing_counts(self):
+        text = "# Title\n\nWe utilize the approach.\n\n%s\n" % filler_words(110)
+        path = self.write("doc.md", text)
+        base = self.evaluate(path)
+        heavy = self.evaluate("--weight", "banned_word=4", path)
+        self.assertEqual(base["counts"], heavy["counts"])
+        self.assertGreater(heavy["rate"], base["rate"])
+
+    def test_exclude_glob_skips_a_path_entirely(self):
+        path = self.write("doc.md", "# Title\n\nWe utilize and leverage it.\n")
+        code, out, _ = self.run_lint("--json", "--exclude", "*.md", path)
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out), [])
+
+    def test_unsupported_extension_is_skipped(self):
+        path = self.write("data.bin", "We utilize the seamless robust approach.\n")
+        code, out, _ = self.run_lint("--json", path)
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out), [])
+
+    def test_include_unknown_treats_extensionless_files_as_prose(self):
+        """This is what lets the strict profile reach a commit message."""
+        path = self.write("COMMIT_EDITMSG", "We utilize the seamless approach.\n")
+        code, out, _ = self.run_lint("--json", path)
+        self.assertEqual(json.loads(out), [])
+        result = self.evaluate("--include-unknown", path)
+        self.assertGreater(sum(result["counts"].values()), 0)
+
+    def test_list_checks_names_every_check(self):
+        code, out, _ = self.run_lint("--list-checks")
+        self.assertEqual(code, 0)
+        for name in prose_lint.ALL_CHECKS:
+            self.assertIn(name, out)
+
+
+class SuppressionTests(Harness):
+    """Some documents have to quote bad prose. Those need an explicit escape."""
+
+    def test_ignore_marker_covers_the_whole_paragraph(self):
+        text = ("# Title\n\nWe utilize the seamless robust approach here and it\n"
+                "spans two lines. <!-- prose-lint: ignore -->\n\n%s\n"
+                % filler_words(110))
+        path = self.write("ig.md", text)
+        self.assertEqual(self.checks(path), {})
+
+    def test_ignore_region_covers_every_line_between_the_markers(self):
+        text = ("# Title\n\n<!-- prose-lint: ignore-start -->\n"
+                "We utilize the seamless approach.\n\nWe leverage the robust one.\n"
+                "<!-- prose-lint: ignore-end -->\n\nWe utilize this.\n")
+        path = self.write("region.md", text)
+        self.assertEqual(self.checks(path).get("banned_word", 0), 1)
+
+    def test_fenced_code_and_inline_code_are_not_prose(self):
+        text = ("# Title\n\n```bash\nutilize --seamless --robust\n```\n\n"
+                "Use `utilize --robust` at the prompt.\n\n%s\n" % filler_words(110))
+        path = self.write("code.md", text)
+        self.assertEqual(self.checks(path), {})
+
+    def test_frontmatter_is_configuration_not_prose(self):
+        text = ("---\ntitle: We utilize the seamless robust approach\n---\n\n"
+                "# Title\n\n%s\n" % filler_words(110))
+        path = self.write("fm.md", text)
+        self.assertEqual(self.checks(path), {})
+
+    def test_link_targets_and_entities_are_not_prose(self):
+        text = ("# Title\n\nSee [the guide](https://example.com/utilize-the-robust)\n"
+                "and note the spacing&nbsp;here.\n\n%s\n" % filler_words(110))
+        path = self.write("links.md", text)
+        counts = self.checks(path)
+        self.assertEqual(counts.get("banned_word", 0), 0)
+        self.assertEqual(counts.get("semicolon", 0), 0)
+
+
+class DocumentExtractionTests(Harness):
+    """Which markdown constructs carry prose, and which are structure."""
+
+    def test_hard_wrapped_sentence_is_measured_whole(self):
+        """A wrapped sentence is one sentence, so its length is one number.
+
+        This is also why a phrase straddling a wrap point is found at all.
+        """
+        text = "# Title\n\nThe parser is\nupdated by the writer.\n"
+        path = self.write("wrap.md", text)
+        self.assertEqual(self.checks(path).get("passive_voice", 0), 1)
+
+    def test_list_items_are_separate_units(self):
+        text = "# Title\n\n- We utilize this.\n- We leverage that.\n"
+        path = self.write("list.md", text)
+        self.assertEqual(self.checks(path).get("banned_word", 0), 2)
+
+    def test_admonitions_and_details_blocks_are_prose(self):
+        text = ("# Title\n\n> [!NOTE]\n> We utilize the approach.\n\n"
+                "<details>\n<summary>More</summary>\n\nWe leverage the other one.\n\n"
+                "</details>\n")
+        path = self.write("adm.md", text)
+        self.assertEqual(self.checks(path).get("banned_word", 0), 2)
+
+    def test_indented_blocks_are_treated_as_code(self):
+        text = "# Title\n\n    utilize the seamless robust thing\n\n%s\n" % filler_words(110)
+        path = self.write("indent.md", text)
+        self.assertEqual(self.checks(path), {})
+
+    def test_every_documentation_extension_is_recognised(self):
+        for ext in sorted(prose_lint.DOC_EXTENSIONS):
+            path = self.write("doc%s" % ext, "We utilize the approach.\n")
+            kind, _ = prose_lint.classify(path, False)
+            self.assertEqual(kind, "doc", "%s should be a document" % ext)
+
+
+class CommentExtractionTests(Harness):
+    """Comments and docstrings are prose. Code and string literals are not."""
+
+    def test_hash_slash_dash_and_markup_comments_are_found(self):
+        cases = [
+            ("mod.sh", "# We utilize the approach.\necho hello\n"),
+            ("mod.js", "// We utilize the approach.\nconst a = 1;\n"),
+            ("mod.js2.js", "/* We utilize the approach. */\nconst a = 1;\n"),
+            ("mod.sql", "-- We utilize the approach.\nSELECT 1;\n"),
+            ("page.html", "<!-- We utilize the approach. -->\n<p>hi</p>\n"),
+            ("mod.tf", "# We utilize the approach.\nvariable \"a\" {}\n"),
+        ]
+        for name, text in cases:
+            path = self.write(name, text)
+            counts = self.checks("--profile", "comments", path)
+            self.assertEqual(counts.get("banned_word", 0), 1,
+                             "%s: comment prose was not found" % name)
+
+    def test_string_literals_are_not_comments(self):
+        text = 'const url = "http://example.com/utilize";\nconst s = "# utilize";\n'
+        path = self.write("mod.js", text)
+        self.assertEqual(self.evaluate("--profile", "comments", path)["words"], 0)
+
+    def test_contiguous_comment_lines_are_rejoined(self):
+        """A phrase split across two comment lines is still one phrase."""
+        text = "// We do this in order\n// to make it work.\nconst a = 1;\n"
+        path = self.write("mod.js", text)
+        self.assertEqual(
+            self.checks("--profile", "comments", path).get("banned_word", 0), 1)
+
+    def test_separated_comment_lines_are_not_rejoined(self):
+        text = "// We do this in order\nconst a = 1;\n// to make it work.\n"
+        path = self.write("mod.js", text)
+        self.assertEqual(
+            self.checks("--profile", "comments", path).get("banned_word", 0), 0)
+
+    def test_block_comment_ornament_is_stripped(self):
+        text = "/*\n * We utilize the approach.\n */\nconst a = 1;\n"
+        path = self.write("mod.js", text)
+        self.assertEqual(
+            self.checks("--profile", "comments", path).get("banned_word", 0), 1)
+
+    def test_comments_profile_enables_only_the_high_signal_checks(self):
+        enabled = set(prose_lint.PROFILES["comments"]["enabled"])
+        self.assertEqual(enabled, set(prose_lint.HIGH_SIGNAL))
+
+
+class PythonExtractionTests(Harness):
+    """A triple-quoted string is a docstring only where the grammar says so."""
+
+    def test_real_docstrings_are_linted(self):
+        text = ('"""We utilize the module approach."""\n\n\n'
+                'class Thing(object):\n    """We leverage the class approach."""\n\n'
+                '    def go(self):\n        """We obtain the method approach."""\n'
+                '        return 1\n')
+        path = self.write("mod.py", text)
+        self.assertEqual(
+            self.checks("--profile", "comments", path).get("banned_word", 0), 3)
+
+    def test_data_in_triple_quotes_is_not_a_docstring(self):
+        """A SQL block, a PEM key and an f-string template are data.
+
+        Scoring them invented findings and padded the word count that every rate
+        divides by. One real file failed a commit on the word inside
+        `b"-----BEGIN PUBLIC KEY-----"`.
+        """
+        text = (
+            'KEY = b"""-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----\n"""\n'
+            'QUERY = """\n    -- We utilize the seamless robust query\n    SELECT 1\n"""\n'
+            'STEP = dict(apply="""\n    We leverage the robust migration\n""")\n'
+        )
+        path = self.write("mod.py", text)
+        result = self.evaluate("--profile", "comments", path)
+        self.assertEqual(result["words"], 0)
+        self.assertEqual(result["counts"], {})
+        self.assertTrue(result["passed"])
+
+    def test_comments_are_still_read_alongside_docstrings(self):
+        text = '# We utilize the approach.\nX = """not a docstring"""\n'
+        path = self.write("mod.py", text)
+        self.assertEqual(
+            self.checks("--profile", "comments", path).get("banned_word", 0), 1)
+
+    def test_shebang_is_configuration_not_prose(self):
+        text = "#!/usr/bin/env python3\nX = 1\n"
+        path = self.write("mod.py", text)
+        self.assertEqual(self.evaluate("--profile", "comments", path)["words"], 0)
+
+    def test_unparseable_source_falls_back_instead_of_being_skipped(self):
+        """A syntax error is a reason to lint less precisely, not to stop."""
+        text = 'def broken(:\n    """We utilize the seamless approach."""\n'
+        path = self.write("mod.py", text)
+        self.assertIsNone(prose_lint.extract_python(text))
+        self.assertGreater(
+            self.checks("--profile", "comments", path).get("banned_word", 0), 0)
+
+
+class DirectiveTests(Harness):
+    """A tool directive is configuration. A documentation tag labels prose."""
+
+    def test_tool_directives_contribute_no_prose(self):
+        for line in ("# noqa: E501 line too long",
+                     "# type: ignore[arg-type]",
+                     "# pylint: disable=invalid-name",
+                     "# ruff: noqa"):
+            self.assertEqual(prose_lint.strip_directive(line.lstrip("# ")), "")
+
+    def test_documentation_tags_keep_their_description(self):
+        """Dropping the whole line hid the prose the tag introduces."""
+        cases = [
+            ("@param cfg - We utilize the approach.", "We utilize the approach."),
+            ("@returns We leverage the result.", "We leverage the result."),
+            ("Note: We obtain the value.", "We obtain the value."),
+            ("See: the design document for the rest", "the design document for the rest"),
+        ]
+        for line, expected in cases:
+            self.assertEqual(prose_lint.strip_directive(line), expected)
+
+    def test_command_syntax_after_a_tag_is_not_prose(self):
+        """The skill puts command syntax out of scope.
+
+        Counting it pads the word count, which dilutes real findings below the
+        threshold rather than adding new ones.
+        """
+        for line in ("Usage: ./run.sh <ID> [out.json]",
+                     "Example: $ curl -sX GET /v1/things",
+                     "Example: run.sh --flag value"):
+            self.assertEqual(prose_lint.strip_directive(line), "")
+
+    def test_prose_naming_a_flag_is_still_prose(self):
+        line = "Note: run with --verbose to see more output when debugging"
+        self.assertTrue(prose_lint.strip_directive(line))
+
+    def test_a_bare_address_carries_no_prose(self):
+        self.assertEqual(prose_lint.strip_directive("https://example.com/utilize"), "")
+
+    def test_an_all_tagged_comment_block_is_still_scored(self):
+        text = ("/**\n * @param a - We utilize the seamless approach.\n"
+                " * @returns We leverage the robust result.\n */\n"
+                "export function go(a) { return a; }\n")
+        path = self.write("mod.js", text)
+        result = self.evaluate("--profile", "comments", path)
+        self.assertGreater(result["words"], 0)
+        self.assertFalse(result["passed"])
+
+
+class LineAttributionTests(Harness):
+    """A finding names the line holding the text it quotes."""
+
+    def test_findings_in_a_wrapped_paragraph_report_their_own_lines(self):
+        text = ("# Title\n\nThe parser reads the file.\n"
+                "But we utilize the robust\napproach in order to facilitate this.\n")
+        path = self.write("attr.md", text)
+        self.assertEqual(self.lines_for("banned_word", path), [4, 5, 5])
+        self.assertEqual(self.lines_for("marketing_adjective", path), [4])
+
+    def test_findings_in_a_comment_run_report_their_own_lines(self):
+        text = "const a = 1;\n// We utilize this\n// and we leverage that.\n"
+        path = self.write("mod.js", text)
+        self.assertEqual(
+            self.lines_for("banned_word", "--profile", "comments", path), [2, 3])
+
+    def test_paragraph_level_findings_stay_on_the_first_line(self):
+        """A paragraph rule is a fact about the block, not about one offset."""
+        body = " ".join("The parser reads record %d." % n for n in range(8))
+        path = self.write("para.md", "# Title\n\n%s\n" % body)
+        self.assertEqual(self.lines_for("long_paragraph", path), [3])
+
+
+class PerformanceTests(Harness):
+    """A guard, not a benchmark.
+
+    The excerpt of a finding was built from the whole unit, once per finding, so a
+    paragraph producing a finding every few words cost O(n^2). A 137KB single
+    paragraph took 3.4 seconds. The bound below is loose enough for a slow machine
+    and still fails if that behaviour returns.
+    """
+
+    def test_a_large_single_paragraph_stays_fast(self):
+        text = "The system is designed to utilize the robust approach. " * 2500
+        path = self.write("big.md", text)
+        started = time.time()
+        self.run_lint("--quiet", path)
+        elapsed = time.time() - started
+        self.assertLess(elapsed, 2.0,
+                        "a %dKB paragraph took %.1fs; the excerpt cost is quadratic "
+                        "again" % (len(text) // 1024, elapsed))
+
+    def test_excerpt_is_bounded_and_still_readable(self):
+        long_text = "word " * 10000
+        trimmed = prose_lint.excerpt(long_text)
+        # width - 1 characters plus the ellipsis that marks the truncation.
+        self.assertLessEqual(len(trimmed), 70)
+        self.assertTrue(trimmed.endswith("..."))
+        self.assertEqual(prose_lint.excerpt("a  b   c"), "a b c")
+
+
+class HostileInputTests(Harness):
+    """Input the linter did not ask for, and must survive anyway."""
+
+    def test_empty_and_whitespace_only_files_are_clean(self):
+        for name, text in (("empty.md", ""), ("blank.md", "\n\n   \n")):
+            path = self.write(name, text)
+            code, _, _ = self.run_lint(path)
+            self.assertEqual(code, 0, "%s should be clean" % name)
+
+    def test_carriage_returns_do_not_shift_line_numbers(self):
+        text = "# Title\r\n\r\nWe utilize the approach.\r\n"
+        path = self.write("crlf.md", text)
+        self.assertEqual(self.lines_for("banned_word", path), [3])
+
+    def test_frontmatter_only_file_is_clean(self):
+        path = self.write("fm.md", "---\ntitle: We utilize this\n---\n")
+        self.assertEqual(self.run_lint(path)[0], 0)
+
+    def test_unterminated_docstring_is_read_to_the_end(self):
+        path = self.write("mod.py", '"""We utilize the seamless approach.\n')
+        code, _, _ = self.run_lint("--profile", "comments", path)
+        self.assertIn(code, (0, 1))
+
+    def test_invalid_utf8_is_replaced_rather_than_raised(self):
+        path = self.write_bytes("latin1.md", b"# Title\n\nCaf\xe9 utilize this.\n")
+        code, _, err = self.run_lint(path)
+        self.assertIn(code, (0, 1), "should not crash: %s" % err)
+        self.assertNotIn("Traceback", err)
+
+    def test_a_single_enormous_line_terminates(self):
+        path = self.write("one.md", "word " * 200000)
+        started = time.time()
+        self.run_lint("--quiet", path)
+        self.assertLess(time.time() - started, 10.0)
+
+
+class GoldenTests(Harness):
+    """One document, pinned whole.
+
+    A per-check breakdown is what turns a rule edit into a reviewable diff. If
+    this test fails, read the change: either a rule moved on purpose, and these
+    numbers should be updated in the same commit, or it moved by accident.
+    """
+
+    DOCUMENT = """---
+title: Widget Service
+---
+
+# Widget Service
+
+The widget service is designed to utilize a seamless approach; it was built to
+facilitate the processing of records. It is important to note that the queue is
+being drained by the worker.
+
+## Setup
+
+1. Start the server.
+2. The configuration is loaded by the server.
+
+> We leverage a myriad of robust techniques.
+
+```bash
+utilize --seamless
+```
+
+Overall, the service performs an analysis of each record. It doesn't retry.
+"""
+
+    # Note what "is being drained" scores: ing_main_verb for "is being" and
+    # passive_voice for "being drained", so one passive costs two violations. That
+    # is current behaviour, pinned here deliberately rather than hidden, because a
+    # fix belongs in a commit that also updates this number.
+    EXPECTED = {
+        "banned_word": 4,
+        "contraction": 1,
+        "empty_closer": 1,
+        "hedge": 1,
+        "ing_main_verb": 1,
+        "marketing_adjective": 2,
+        "nominalization": 1,
+        "passive_voice": 4,
+        "semicolon": 1,
+    }
+    EXPECTED_WORDS = 65
+
+    def test_pinned_document(self):
+        path = self.write("golden.md", self.DOCUMENT)
+        result = self.evaluate(path)
+        self.assertEqual(result["counts"], self.EXPECTED)
+        self.assertEqual(result["words"], self.EXPECTED_WORDS)
+        self.assertFalse(result["passed"])
+
+    def test_pinned_document_word_count_excludes_structure(self):
+        """Frontmatter, the fenced block and the heading markers are not words."""
+        path = self.write("golden.md", self.DOCUMENT)
+        self.assertLess(self.evaluate(path)["words"],
+                        len(self.DOCUMENT.split()),
+                        "structure is being counted as prose")
+
+    def test_pinned_document_is_clean_when_every_check_is_off(self):
+        path = self.write("golden.md", self.DOCUMENT)
+        args = []
+        for name in prose_lint.ALL_CHECKS:
+            args += ["--disable", name]
+        result = self.evaluate(*(args + [path]))
+        self.assertEqual(result["counts"], {})
+        self.assertTrue(result["passed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prose_lint.py
+++ b/tests/test_prose_lint.py
@@ -161,6 +161,49 @@ class ExitCodeTests(Harness):
         self.assertIn("utilize", err)
         self.assertIn("not blocking", err)
 
+    def test_warn_only_does_not_call_a_warning_a_failure(self):
+        """Printing FAIL and "not blocking" together contradicts itself."""
+        text = "# Title\n\nWe utilize and leverage and obtain this.\n"
+        path = self.write("warn.md", text)
+        _, _, err = self.run_lint("--warn-only", path)
+        self.assertIn(" WARN ", err)
+        self.assertNotIn(" FAIL ", err)
+        # The blocking run is the one that says FAIL.
+        _, _, blocking = self.run_lint(path)
+        self.assertIn(" FAIL ", blocking)
+        self.assertNotIn(" WARN ", blocking)
+
+    def test_warn_only_reports_findings_in_a_file_that_passes(self):
+        """A finding under budget is still worth surfacing in warn mode."""
+        text = "# Title\n\nWe utilize the approach.\n\n%s\n" % filler_words(110)
+        path = self.write("under.md", text)
+        self.assertEqual(self.run_lint(path)[0], 0)
+        code, _, err = self.run_lint("--warn-only", path)
+        self.assertEqual(code, 0)
+        self.assertIn("utilize", err)
+        # Nothing was over budget, so there is no summary line to print.
+        self.assertNotIn("not blocking", err)
+
+    def test_warn_only_does_not_downgrade_a_configuration_error(self):
+        """A misconfigured hook is not a warning, so it still exits 2."""
+        path = self.write("doc.md", "# Title\n\nWe utilize this.\n")
+        missing = os.path.join(tempfile.gettempdir(), "prose-lint-absent.md")
+        cases = [
+            ("--weight", "semicolon=bar", path),
+            ("--profile", "nope", path),
+            ("--warn-only", missing),
+        ]
+        for case in cases:
+            args = ("--warn-only",) + case if case[0] != "--warn-only" else case
+            self.assertEqual(self.run_lint(*args)[0], 2,
+                             "%s should still exit 2 under --warn-only" % (args,))
+
+    def test_warn_only_is_silent_on_clean_prose(self):
+        path = self.write("clean.md", "# Title\n\n%s\n" % filler_words(120))
+        code, _, err = self.run_lint("--warn-only", path)
+        self.assertEqual(code, 0)
+        self.assertEqual(err.strip(), "")
+
     def test_unknown_profile_exits_two(self):
         path = self.write("doc.md", "# Title\n")
         self.assertEqual(self.run_lint("--profile", "nope", path)[0], 2)

--- a/tests/test_prose_lint.py
+++ b/tests/test_prose_lint.py
@@ -579,6 +579,94 @@ class DirectiveTests(Harness):
         self.assertFalse(result["passed"])
 
 
+class FragmentTests(Harness):
+    """Sentence-level rules need a sentence to apply to.
+
+    A semicolon rule says "write two sentences". In a table cell there is no room
+    for two, a heading is a fragment, and an unpunctuated list item is a label
+    joining items rather than clauses. 57% of semicolon findings measured across
+    17 repositories sat in one of those three.
+    """
+
+    def test_semicolon_in_a_table_cell_is_not_reported(self):
+        text = ("# Title\n\n| Name | Detail |\n|---|---|\n"
+                "| a | Tries OAuth first; falls back to JWT |\n")
+        path = self.write("table.md", text)
+        self.assertEqual(self.checks(path).get("semicolon", 0), 0)
+
+    def test_semicolon_in_a_label_list_item_is_not_reported(self):
+        text = "# Title\n\n- **Read-only:** kubectl get/describe; helm list/status\n"
+        path = self.write("label.md", text)
+        self.assertEqual(self.checks(path).get("semicolon", 0), 0)
+
+    def test_semicolon_in_a_punctuated_list_item_is_still_reported(self):
+        """A list item written as prose is prose, and the edit is available."""
+        text = "# Title\n\n- The parser reads the file; the writer stores it.\n"
+        path = self.write("proselist.md", text)
+        self.assertEqual(self.checks(path).get("semicolon", 0), 1)
+
+    def test_semicolon_joining_clauses_in_prose_is_still_reported(self):
+        text = "# Title\n\nThe parser reads the file; the writer stores the record.\n"
+        path = self.write("clauses.md", text)
+        self.assertEqual(self.checks(path).get("semicolon", 0), 1)
+
+    def test_tldr_is_one_token_not_two_clauses(self):
+        path = self.write("tldr.md", "# Title\n\nTL;DR the parser reads the file.\n")
+        self.assertEqual(self.checks(path).get("semicolon", 0), 0)
+
+
+class ParticipleTests(Harness):
+    """A participle can report a state instead of an action."""
+
+    def test_stative_participles_are_not_progressive_verbs(self):
+        text = ("# Title\n\nVerify the server is running. No other process is\n"
+                "using port 8000. The header is missing.\n")
+        path = self.write("state.md", text)
+        self.assertEqual(self.checks(path).get("ing_main_verb", 0), 0)
+
+    def test_a_real_progressive_is_still_reported(self):
+        path = self.write("prog.md", "# Title\n\nThe team is introducing a new field.\n")
+        self.assertEqual(self.checks(path).get("ing_main_verb", 0), 1)
+
+    def test_one_passive_is_charged_once(self):
+        """"is being drained" is one defect, not two."""
+        path = self.write("dbl.md", "# Title\n\nThe queue is being drained by the worker.\n")
+        counts = self.checks(path)
+        self.assertEqual(counts.get("passive_voice", 0), 1)
+        self.assertEqual(counts.get("ing_main_verb", 0), 0)
+
+    def test_predicate_adjectives_are_not_passives(self):
+        text = ("# Title\n\nThe flag is needed. The file is unused. The pattern is\n"
+                "unchanged. The token is expired. The route is unauthenticated.\n")
+        path = self.write("adj.md", text)
+        self.assertEqual(self.checks(path).get("passive_voice", 0), 0)
+
+    def test_a_real_passive_is_still_reported(self):
+        path = self.write("pass.md", "# Title\n\nThe record is written by the worker.\n")
+        self.assertEqual(self.checks(path).get("passive_voice", 0), 1)
+
+
+class NominalizationTests(Harness):
+    """A noun ending in -tion is not automatically a buried verb."""
+
+    def test_ordinary_noun_phrases_are_not_nominalizations(self):
+        text = ("# Title\n\nThe location of the bucket, the description of the\n"
+                "field, and the combination of the two.\n")
+        path = self.write("nouns.md", text)
+        self.assertEqual(self.checks(path).get("nominalization", 0), 0)
+
+    def test_buried_verbs_are_still_reported(self):
+        text = "# Title\n\nIt simplifies the detection of drift after the deprecation of v1.\n"
+        path = self.write("buried.md", text)
+        self.assertEqual(self.checks(path).get("nominalization", 0), 2)
+
+    def test_perform_needs_a_nominalized_object(self):
+        path = self.write("bare.md", "# Title\n\nClients that perform PKCE directly.\n")
+        self.assertEqual(self.checks(path).get("nominalization", 0), 0)
+        path = self.write("obj.md", "# Title\n\nIt performs an analysis of each record.\n")
+        self.assertEqual(self.checks(path).get("nominalization", 0), 1)
+
+
 class LineAttributionTests(Harness):
     """A finding names the line holding the text it quotes."""
 
@@ -698,16 +786,17 @@ utilize --seamless
 Overall, the service performs an analysis of each record. It doesn't retry.
 """
 
-    # Note what "is being drained" scores: ing_main_verb for "is being" and
-    # passive_voice for "being drained", so one passive costs two violations. That
-    # is current behaviour, pinned here deliberately rather than hidden, because a
-    # fix belongs in a commit that also updates this number.
+    # "is being drained" scores passive_voice once, for "being drained". It used
+    # to also score ing_main_verb for "is being", charging one passive twice.
+    #
+    # "the processing of records" scores nothing: `processing` does not end in a
+    # nominalising suffix. "performs an analysis of" scores once, because that
+    # one really does bury a verb.
     EXPECTED = {
         "banned_word": 4,
         "contraction": 1,
         "empty_closer": 1,
         "hedge": 1,
-        "ing_main_verb": 1,
         "marketing_adjective": 2,
         "nominalization": 1,
         "passive_voice": 4,


### PR DESCRIPTION
Adds pre-commit hooks that score prose against the technical-writing rules: `prose-lint` for documentation files and `prose-lint-comments` for comments and docstrings in source, plus warn-only variants of each. Language-agnostic, dependency-free, configurable per repository.

Validated against 17 repositories (3,429 files, 368k words). That run drove the rest of the branch:

- Python docstrings resolved with `ast` rather than regex, so SQL blocks and PEM keys are no longer scored as prose (23% word-count inflation, and one file failing a commit on a base64 key).
- Documentation tags keep the prose they introduce; previously 11.7% of comment words were discarded and an all-marketing JSDoc block passed clean.
- Findings report the line holding the text, not the paragraph's first line.
- Four rules exempted where measurement showed them wrong more often than right: fragment semicolons, predicate adjectives, stative participles and concrete nominalisations. Documents 2,515 findings to 2,186, and 89 failing files to 66, with no file newly failing.
- Misconfiguration exits 2 instead of tracebacking as exit 1.
- `excerpt()` bounded, removing quadratic cost on large paragraphs (137KB paragraph: 3.40s to 0.27s).
- Stdlib-only test suite, 86 tests, with a golden document pinned check by check.

## Adoption

Hooks block by default. The measured cost of that differs sharply by repository: over the last 20 commits, the blocking documentation hook would stop 81% of commits on a knowledge repository and 64% on a prompt repository, against roughly 0% on service and template repos, because most commits there touch no documentation at all.

So `prose-lint-warn` and `prose-lint-comments-warn` ship alongside: same checks, reported without failing, `verbose: true` set so the warnings are actually visible. Block on what a team writes, warn on what it inherited, switch over once the backlog is clear.

The README states the warn-only convention once for every hook in this repo rather than for prose-lint alone: `--warn-only` downgrades findings and exits 0, a configuration error still fails, and warning output says `WARN` not `FAIL`. `todo`/`regex` already follow it; `generated-sidecar`, `decorator-kwargs` and `yaml-sync` do not implement the flag yet.

## Keeping the skill in sync

The matching rule changes land in the `technical-writing` skill's `doclint.py`, so the two tools do not report different numbers for the same text. All shared rule tables are byte-identical and per-check counts agree on 85% of 130 real documents, up from 82%.

## Known gaps, deliberately not in this branch

- An unterminated code fence still suppresses linting for the rest of a file and exits 0.
- `todo_marker` and blockquote joining still differ from the skill's linter.
- The comments glob misses `.yaml`/`.yml` and the extensionless `Dockerfile`/`Makefile` entries the linter already supports (241 files, 6.5k comment words in the sample).
- No CI workflow runs the test suite.
